### PR TITLE
[#29] feat : 로그인 유저 정보 실시간으로 받아오기

### DIFF
--- a/src/components/routes/PrivateRoute.tsx
+++ b/src/components/routes/PrivateRoute.tsx
@@ -1,21 +1,40 @@
 import React, { useEffect } from "react";
 import { Outlet, useNavigate } from "react-router-dom";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { doc, onSnapshot } from "firebase/firestore";
 
+import { db } from "../../firebaseSDK";
 import Header from "../Header";
 import loginState from "../../recoil/atoms/login/loginState";
+import userDataState from "../../recoil/atoms/login/userDataState";
 
 export default function PrivateRoute() {
   const navigate = useNavigate();
-  const loginStateValue = useRecoilValue(loginState);
+  const { isLogin, userCredential } = useRecoilValue(loginState);
+  const setUserDataState = useSetRecoilState(userDataState);
 
   useEffect(() => {
-    if (!loginStateValue) {
+    if (!isLogin) {
       navigate("/login");
     }
-  });
+  }, []);
 
-  return loginStateValue === true ? (
+  if (isLogin) {
+    useEffect(() => {
+      // 1. onSnapShot 메서드로 문서 (유저 정보) 구독
+      const userRef = doc(db, "user", userCredential.uid);
+      const unsub = onSnapshot(userRef, (userDoc) => {
+        // 2. 변경시마다 useSetRecoilState를 이용해서 atom 업데이트
+        setUserDataState({
+          userData: userDoc.data(),
+        });
+      });
+      // 3. 클린업 함수에서 구독 중지 메서드 실행
+      return () => unsub();
+    }, []);
+  }
+
+  return isLogin === true ? (
     <>
       <Header />
       <Outlet />

--- a/src/components/routes/PublicRoute.tsx
+++ b/src/components/routes/PublicRoute.tsx
@@ -7,13 +7,13 @@ import loginState from "../../recoil/atoms/login/loginState";
 export default function PublicRoute() {
   const navigate = useNavigate();
 
-  const loginStateValue = useRecoilValue(loginState);
+  const { isLogin } = useRecoilValue(loginState);
 
   useEffect(() => {
-    if (loginStateValue) {
+    if (isLogin) {
       navigate("/");
     }
   }, []);
 
-  return loginStateValue === true ? null : <Outlet />;
+  return isLogin === true ? null : <Outlet />;
 }

--- a/src/pages/LoginPage/Login.tsx
+++ b/src/pages/LoginPage/Login.tsx
@@ -7,7 +7,6 @@ import styled from "styled-components";
 import { doc, getDoc, setDoc } from "firebase/firestore";
 import { auth, db } from "../../firebaseSDK";
 import loginState from "../../recoil/atoms/login/loginState";
-import userState from "../../recoil/atoms/login/userState";
 import ShrikhandRegular from "../../assets/fonts/Shrikhand-Regular.ttf";
 import RobotoRegular from "../../assets/fonts/Roboto-Regular.ttf";
 import loginBackground from "../../assets/images/loginBackground.svg";
@@ -83,7 +82,6 @@ export default function Login() {
   const navigate = useNavigate();
 
   const setLoginState = useSetRecoilState(loginState);
-  const setUserState = useSetRecoilState(userState);
 
   const provider = new GoogleAuthProvider();
 
@@ -113,14 +111,12 @@ export default function Login() {
           });
         }
 
-        return { user, userRef };
+        return { user };
       })
-      .then(async ({ user, userRef }) => {
-        const userSnap = await getDoc(userRef);
-        setLoginState(true);
-        setUserState({
+      .then(async ({ user }) => {
+        setLoginState({
+          isLogin: true,
           userCredential: JSON.parse(JSON.stringify(user)),
-          userData: userSnap.data(),
         });
         navigate("/");
       })

--- a/src/recoil/atoms/login/loginState.ts
+++ b/src/recoil/atoms/login/loginState.ts
@@ -6,9 +6,19 @@ const { persistAtom } = recoilPersist({
   storage: localStorage,
 });
 
+interface LoginStateDefault {
+  isLogin: boolean;
+  userCredential: unknown;
+}
+
+const defaultValue: LoginStateDefault = {
+  isLogin: false,
+  userCredential: null,
+};
+
 const loginState = atom({
   key: "isLogin",
-  default: false,
+  default: defaultValue,
   effects_UNSTABLE: [persistAtom],
 });
 

--- a/src/recoil/atoms/login/userDataState.ts
+++ b/src/recoil/atoms/login/userDataState.ts
@@ -2,12 +2,10 @@ import { atom } from "recoil";
 import { recoilPersist } from "recoil-persist";
 
 interface UserStateDefault {
-  userInfo: unknown;
   userData: unknown;
 }
 
 const defaultValue: UserStateDefault = {
-  userInfo: null,
   userData: null,
 };
 


### PR DESCRIPTION
### ⛳️ Task

- [x]  로그인 유저 정보 실시간으로 받아오기

### ✍️ Note

- onSnapshot 메서드를 이용하여 PrivateRoute에서 유저 정보를 실시간으로 가져옵니다,
- loginState와 userDataState(userState에서 이름 변경)가 변경 및 추가 되었습니다. loginState, userDataState를 사용하시는 분은 객체 분해 할당 로직을 이용하셔서 아래처럼 이용하실 수 있습니다.
  - loginState -> 로그인 유무 및 Firebase auth 에서 받아온 유저 정보
  - userDataState -> Firebase FireStore에서 받아온 유저 정보
- loginState에 변화가 생겨 public, private 라우터의 코드 변경이 생겼습니다.
```
const { isLogin, userCredential } = useRecoilValue(loginState);
const { userData } = useRecoilValue(userDataState)
```
  
### 📸 Screenshot

### 📎 Reference

close #29 