### PR TITLE
[#48] refactor : ProjectModalContent 스타일 컴포넌트 제거

### DIFF
--- a/src/components/layout/ProjectModalLayout.tsx
+++ b/src/components/layout/ProjectModalLayout.tsx
@@ -53,14 +53,6 @@ const ProjectModalContentBox = styled.div`
   border-radius: 0.6rem 0.6rem 0 0;
   box-shadow: 0px 0px 10px 6px rgba(0, 0, 0, 0.1);
 
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-`;
-
-const ProjectModalContent = styled.div`
-  border-radius: 0.6rem 0.6rem 0 0;
-
   overflow: scroll;
   -ms-overflow-style: none;
   &::-webkit-scrollbar {
@@ -74,5 +66,4 @@ export {
   ProjectModalTabText,
   ProjectModalTabBackground,
   ProjectModalContentBox,
-  ProjectModalContent,
 };

--- a/src/pages/ProjectPage/KanbanModal/KanbanModal.tsx
+++ b/src/pages/ProjectPage/KanbanModal/KanbanModal.tsx
@@ -8,7 +8,6 @@ import {
   ProjectModalTabText,
   ProjectModalTabBox,
   ProjectModalContentBox,
-  ProjectModalContent,
 } from "../../../components/layout/ProjectModalLayout";
 
 type Props = {
@@ -49,18 +48,16 @@ export default function KanbanModal({ kanbanTabColor, isKanbanShow }: Props) {
         </ProjectModalTabText>
       </ProjectModalTabBox>
       <ProjectModalContentBox>
-        <ProjectModalContent>
-          <TestBtn type="button" onClick={() => handleCalClick()}>
-            calender
-          </TestBtn>
-          <TestBtn type="button" onClick={() => handlekanbanCLick()}>
-            kanban
-          </TestBtn>
-          <TestBtn type="button" onClick={() => handleTodoCLick()}>
-            todo
-          </TestBtn>
-          <div>kanban</div>
-        </ProjectModalContent>
+        <TestBtn type="button" onClick={() => handleCalClick()}>
+          calender
+        </TestBtn>
+        <TestBtn type="button" onClick={() => handlekanbanCLick()}>
+          kanban
+        </TestBtn>
+        <TestBtn type="button" onClick={() => handleTodoCLick()}>
+          todo
+        </TestBtn>
+        <div>kanban</div>
       </ProjectModalContentBox>
     </ProjectModalLayout>
   );

--- a/src/pages/ProjectPage/Project.tsx
+++ b/src/pages/ProjectPage/Project.tsx
@@ -8,7 +8,6 @@ import {
   ProjectModalTabText,
   ProjectModalTabBox,
   ProjectModalContentBox,
-  ProjectModalContent,
 } from "../../components/layout/ProjectModalLayout";
 import KanbanModal from "./KanbanModal/KanbanModal";
 import TodoModal from "./TodoModal/TodoModal";
@@ -88,18 +87,15 @@ export default function Project() {
           </ProjectModalTabText>
         </ProjectModalTabBox>
         <ProjectModalContentBox>
-          <ProjectModalContent>
-            <TestBtn type="button" onClick={() => handleCalClick()}>
-              calender
-            </TestBtn>
-            <TestBtn type="button" onClick={() => handlekanbanCLick()}>
-              kanban
-            </TestBtn>
-            <TestBtn type="button" onClick={() => handleTodoCLick()}>
-              todo
-            </TestBtn>
-            <div>calender</div>
-          </ProjectModalContent>
+          <TestBtn type="button" onClick={() => handleCalClick()}>
+            calender
+          </TestBtn>
+          <TestBtn type="button" onClick={() => handlekanbanCLick()}>
+            kanban
+          </TestBtn>
+          <TestBtn type="button" onClick={() => handleTodoCLick()}>
+            todo
+          </TestBtn>
         </ProjectModalContentBox>
       </ProjectModalLayout>
       {/* 칸반 */}

--- a/src/pages/ProjectPage/TodoModal/TodoModal.tsx
+++ b/src/pages/ProjectPage/TodoModal/TodoModal.tsx
@@ -8,7 +8,6 @@ import {
   ProjectModalTabText,
   ProjectModalTabBox,
   ProjectModalContentBox,
-  ProjectModalContent,
 } from "../../../components/layout/ProjectModalLayout";
 
 type Props = {
@@ -49,18 +48,16 @@ export default function TodoModal({ todoTabColor, isTodoShow }: Props) {
         </ProjectModalTabText>
       </ProjectModalTabBox>
       <ProjectModalContentBox>
-        <ProjectModalContent>
-          <TestBtn type="button" onClick={() => handleCalClick()}>
-            calender
-          </TestBtn>
-          <TestBtn type="button" onClick={() => handlekanbanCLick()}>
-            kanban
-          </TestBtn>
-          <TestBtn type="button" onClick={() => handleTodoCLick()}>
-            todo
-          </TestBtn>
-          <div>Todo</div>
-        </ProjectModalContent>
+        <TestBtn type="button" onClick={() => handleCalClick()}>
+          calender
+        </TestBtn>
+        <TestBtn type="button" onClick={() => handlekanbanCLick()}>
+          kanban
+        </TestBtn>
+        <TestBtn type="button" onClick={() => handleTodoCLick()}>
+          todo
+        </TestBtn>
+        <div>Todo</div>
       </ProjectModalContentBox>
     </ProjectModalLayout>
   );


### PR DESCRIPTION
### ⛳️ Task

- [x] ProjectModalLayout.tsx 내 ProjectModalContent 스타일 컴포넌트 제거
  - ProjectModalContent 스타일 컴포넌트를 사용하던 Project.tsx, KanbanModal.tsx, TodoModal.tsx 도 수정하였습니다.

### ✍️ Note

### 📸 Screenshot

### 📎 Reference

close #48 