### PR TITLE
[#53] design : 헤더 내 각 모달 구조 변경 

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,7 +21,7 @@ import UserProfile from "./modal/UserProfileModal";
 import ModalCommon from "./layout/ModalCommonLayout";
 
 const HeaderLayout = styled.div`
-  height: 9vh;
+  height: 4rem;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/components/layout/ModalCommonLayout.tsx
+++ b/src/components/layout/ModalCommonLayout.tsx
@@ -1,6 +1,17 @@
 import React, { useState, useEffect, ReactElement } from "react";
 import { styled } from "styled-components";
 
+interface Props {
+  $dynamicWidth?: string;
+  $dynamicHeight?: string;
+}
+
+interface ModalInfo {
+  modalSelected: number;
+  modalIndex: number;
+  children: ReactElement;
+}
+
 const ModalLayout = styled.div`
   height: 100%;
 `;
@@ -12,9 +23,9 @@ const ModalBox = styled.div`
   position: relative;
 `;
 
-export const ModalArea = styled.div`
-  width: 20rem;
-  height: 20rem;
+export const ModalArea = styled.div<Props>`
+  width: ${(props) => (props.$dynamicWidth ? props.$dynamicWidth : "20rem")};
+  height: ${(props) => (props.$dynamicHeight ? props.$dynamicHeight : "20rem")};
   z-index: 999;
   position: absolute;
   right: 0;
@@ -23,19 +34,13 @@ export const ModalArea = styled.div`
   box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
 `;
 
-interface ModalInfo {
-  modalSelected: number;
-  modalIndex: number;
-  children: ReactElement;
-}
-
 export default function ModalCommon(name: ModalInfo) {
   const { modalIndex, modalSelected, children } = name;
   const [activeIndex, setActiveIndex] = useState<number>();
 
   const handleClick = () => {
     if (activeIndex === modalIndex) {
-      // 같은 모달 아이콘 클릭시 기본 값 -1 부여를 통한 모달 닫힘 처리
+    // 같은 모달 아이콘 클릭시 기본 값 -1 부여를 통한 모달 닫힘 처리
       setActiveIndex(-1);
     } else {
       setActiveIndex(modalSelected);

--- a/src/components/layout/ModalCommonLayout.tsx
+++ b/src/components/layout/ModalCommonLayout.tsx
@@ -57,14 +57,12 @@ export default function ModalCommon(name: ModalInfo) {
   return (
     <ModalLayout>
       <ModalBox onClick={() => handleClick()}>
-        <>
-          <img src={children.props.children[0]} alt="modalIcon" />
-          {activeIndex === modalIndex ? (
-            <ModalArea className="isShow">
-              {children.props.children[1]}
-            </ModalArea>
-          ) : null}
-        </>
+        <img src={children.props.children[0]} alt="modalIcon" />
+        {activeIndex === modalIndex ? (
+          <ModalArea className="isShow">
+            {children.props.children[1]}
+          </ModalArea>
+        ) : null}
       </ModalBox>
     </ModalLayout>
   );

--- a/src/components/layout/ModalCommonLayout.tsx
+++ b/src/components/layout/ModalCommonLayout.tsx
@@ -12,24 +12,6 @@ const ModalBox = styled.div`
   position: relative;
 `;
 
-const ModalArea = styled.div`
-  width: 20rem;
-  height: 20rem;
-  z-index: 999;
-  position: absolute;
-  right: 0;
-  top: 4rem;
-  border-radius: 7px;
-  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
-
-  &.isHide {
-    display: none;
-  }
-
-  &.isShow {
-    display: block;
-  }
-`;
 
 interface ModalInfo {
   modalSelected: number;
@@ -58,11 +40,7 @@ export default function ModalCommon(name: ModalInfo) {
     <ModalLayout>
       <ModalBox onClick={() => handleClick()}>
         <img src={children.props.children[0]} alt="modalIcon" />
-        {activeIndex === modalIndex ? (
-          <ModalArea className="isShow">
-            {children.props.children[1]}
-          </ModalArea>
-        ) : null}
+        {activeIndex === modalIndex ? children.props.children[1] : null}
       </ModalBox>
     </ModalLayout>
   );

--- a/src/components/layout/ModalCommonLayout.tsx
+++ b/src/components/layout/ModalCommonLayout.tsx
@@ -12,6 +12,24 @@ const ModalBox = styled.div`
   position: relative;
 `;
 
+export const ModalArea = styled.div`
+  width: 20rem;
+  height: 20rem;
+  z-index: 999;
+  position: absolute;
+  right: 0;
+  top: 4rem;
+  border-radius: 7px;
+  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
+
+  &.isHide {
+    display: none;
+  }
+
+  &.isShow {
+    display: block;
+  }
+`;
 
 interface ModalInfo {
   modalSelected: number;

--- a/src/components/layout/ModalCommonLayout.tsx
+++ b/src/components/layout/ModalCommonLayout.tsx
@@ -21,14 +21,6 @@ export const ModalArea = styled.div`
   top: 4rem;
   border-radius: 7px;
   box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
-
-  &.isHide {
-    display: none;
-  }
-
-  &.isShow {
-    display: block;
-  }
 `;
 
 interface ModalInfo {

--- a/src/components/modal/BookMarkModal.tsx
+++ b/src/components/modal/BookMarkModal.tsx
@@ -1,25 +1,5 @@
 import React from "react";
-import { styled } from "styled-components";
-
-const ModalArea = styled.div`
-  width: 20rem;
-  height: 20rem;
-  z-index: 999;
-  position: absolute;
-  right: 0;
-  top: 4rem;
-  border-radius: 7px;
-  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
-
-  &.isHide {
-    display: none;
-  }
-
-  &.isShow {
-    display: block;
-  }
-`;
-
+import { ModalArea } from "../layout/ModalCommonLayout";
 
 export default function Bookmark() {
   return <ModalArea><div>BookMark</div>;</ModalArea>

--- a/src/components/modal/BookMarkModal.tsx
+++ b/src/components/modal/BookMarkModal.tsx
@@ -1,5 +1,26 @@
 import React from "react";
+import { styled } from "styled-components";
+
+const ModalArea = styled.div`
+  width: 20rem;
+  height: 20rem;
+  z-index: 999;
+  position: absolute;
+  right: 0;
+  top: 4rem;
+  border-radius: 7px;
+  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
+
+  &.isHide {
+    display: none;
+  }
+
+  &.isShow {
+    display: block;
+  }
+`;
+
 
 export default function Bookmark() {
-  return <div>BookMark</div>;
+  return <ModalArea><div>BookMark</div>;</ModalArea>
 }

--- a/src/components/modal/BookMarkModal.tsx
+++ b/src/components/modal/BookMarkModal.tsx
@@ -1,6 +1,19 @@
 import React from "react";
 import { ModalArea } from "../layout/ModalCommonLayout";
 
+const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  // 모달 컴포넌트 영역 클릭시 클릭 이벤트가 부모로 전달되어 컴포넌트가 닫히는 현상 수정
+  event.stopPropagation()
+}
+
 export default function Bookmark() {
-  return <ModalArea><div>BookMark</div>;</ModalArea>
+  return (
+    <ModalArea
+      $dynamicWidth=""
+      $dynamicHeight=""
+      onClick={handleClick}
+    >
+      <div>BookMark</div>
+    </ModalArea>
+  );
 }

--- a/src/components/modal/LogModal.tsx
+++ b/src/components/modal/LogModal.tsx
@@ -1,6 +1,19 @@
 import React from "react";
 import { ModalArea } from "../layout/ModalCommonLayout";
 
+const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  // 모달 컴포넌트 영역 클릭시 클릭 이벤트가 부모로 전달되어 컴포넌트가 닫히는 현상 수정
+  event.stopPropagation()
+}
+
 export default function Log() {
-  return <ModalArea><div>Log</div></ModalArea>;
+  return (
+    <ModalArea
+      $dynamicWidth=""
+      $dynamicHeight=""
+      onClick={handleClick}
+    >
+      <div>Log</div>
+    </ModalArea>
+  );
 }

--- a/src/components/modal/LogModal.tsx
+++ b/src/components/modal/LogModal.tsx
@@ -1,5 +1,25 @@
 import React from "react";
+import { styled } from "styled-components";
+
+const ModalArea = styled.div`
+  width: 20rem;
+  height: 20rem;
+  z-index: 999;
+  position: absolute;
+  right: 0;
+  top: 4rem;
+  border-radius: 7px;
+  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
+
+  &.isHide {
+    display: none;
+  }
+
+  &.isShow {
+    display: block;
+  }
+`;
 
 export default function Log() {
-  return <div>Log</div>;
+  return <ModalArea><div>Log</div></ModalArea>;
 }

--- a/src/components/modal/LogModal.tsx
+++ b/src/components/modal/LogModal.tsx
@@ -1,24 +1,5 @@
 import React from "react";
-import { styled } from "styled-components";
-
-const ModalArea = styled.div`
-  width: 20rem;
-  height: 20rem;
-  z-index: 999;
-  position: absolute;
-  right: 0;
-  top: 4rem;
-  border-radius: 7px;
-  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
-
-  &.isHide {
-    display: none;
-  }
-
-  &.isShow {
-    display: block;
-  }
-`;
+import { ModalArea } from "../layout/ModalCommonLayout";
 
 export default function Log() {
   return <ModalArea><div>Log</div></ModalArea>;

--- a/src/components/modal/ProjectMemberModal.tsx
+++ b/src/components/modal/ProjectMemberModal.tsx
@@ -1,24 +1,6 @@
 import React from "react";
-import { styled } from "styled-components";
+import { ModalArea } from "../layout/ModalCommonLayout";
 
-const ModalArea = styled.div`
-  width: 20rem;
-  height: 20rem;
-  z-index: 999;
-  position: absolute;
-  right: 0;
-  top: 4rem;
-  border-radius: 7px;
-  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
-
-  &.isHide {
-    display: none;
-  }
-
-  &.isShow {
-    display: block;
-  }
-`;
 export default function ProjectMember() {
   return <ModalArea><div>ProjectMember</div></ModalArea>;
 }

--- a/src/components/modal/ProjectMemberModal.tsx
+++ b/src/components/modal/ProjectMemberModal.tsx
@@ -1,6 +1,19 @@
 import React from "react";
 import { ModalArea } from "../layout/ModalCommonLayout";
 
+const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  // 모달 컴포넌트 영역 클릭시 클릭 이벤트가 부모로 전달되어 컴포넌트가 닫히는 현상 수정
+  event.stopPropagation()
+}
+
 export default function ProjectMember() {
-  return <ModalArea><div>ProjectMember</div></ModalArea>;
+  return (
+    <ModalArea
+      $dynamicWidth=""
+      $dynamicHeight=""
+      onClick={handleClick}
+    >
+      <div>ProjectMember</div>
+    </ModalArea>
+  );
 }

--- a/src/components/modal/ProjectMemberModal.tsx
+++ b/src/components/modal/ProjectMemberModal.tsx
@@ -1,5 +1,24 @@
 import React from "react";
+import { styled } from "styled-components";
 
+const ModalArea = styled.div`
+  width: 20rem;
+  height: 20rem;
+  z-index: 999;
+  position: absolute;
+  right: 0;
+  top: 4rem;
+  border-radius: 7px;
+  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
+
+  &.isHide {
+    display: none;
+  }
+
+  &.isShow {
+    display: block;
+  }
+`;
 export default function ProjectMember() {
-  return <div>ProjectMember</div>;
+  return <ModalArea><div>ProjectMember</div></ModalArea>;
 }

--- a/src/components/modal/TutorialModal.tsx
+++ b/src/components/modal/TutorialModal.tsx
@@ -1,24 +1,6 @@
 import React from "react";
-import { styled } from "styled-components";
+import { ModalArea } from "../layout/ModalCommonLayout";
 
-const ModalArea = styled.div`
-  width: 20rem;
-  height: 20rem;
-  z-index: 999;
-  position: absolute;
-  right: 0;
-  top: 4rem;
-  border-radius: 7px;
-  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
-
-  &.isHide {
-    display: none;
-  }
-
-  &.isShow {
-    display: block;
-  }
-`;
 export default function Tutorial() {
   return <ModalArea><div>Tutorial</div></ModalArea>;
 }

--- a/src/components/modal/TutorialModal.tsx
+++ b/src/components/modal/TutorialModal.tsx
@@ -1,5 +1,24 @@
 import React from "react";
+import { styled } from "styled-components";
 
+const ModalArea = styled.div`
+  width: 20rem;
+  height: 20rem;
+  z-index: 999;
+  position: absolute;
+  right: 0;
+  top: 4rem;
+  border-radius: 7px;
+  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
+
+  &.isHide {
+    display: none;
+  }
+
+  &.isShow {
+    display: block;
+  }
+`;
 export default function Tutorial() {
-  return <div>Tutorial</div>;
+  return <ModalArea><div>Tutorial</div></ModalArea>;
 }

--- a/src/components/modal/TutorialModal.tsx
+++ b/src/components/modal/TutorialModal.tsx
@@ -1,6 +1,19 @@
 import React from "react";
 import { ModalArea } from "../layout/ModalCommonLayout";
 
+const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  // 모달 컴포넌트 영역 클릭시 클릭 이벤트가 부모로 전달되어 컴포넌트가 닫히는 현상 수정
+  event.stopPropagation()
+}
+
 export default function Tutorial() {
-  return <ModalArea><div>Tutorial</div></ModalArea>;
+  return (
+    <ModalArea
+      $dynamicWidth=""
+      $dynamicHeight=""
+      onClick={handleClick}
+    >
+      <div>Tutorial</div>
+    </ModalArea>
+  );
 }

--- a/src/components/modal/UserProfileModal.tsx
+++ b/src/components/modal/UserProfileModal.tsx
@@ -1,5 +1,24 @@
 import React from "react";
+import { styled } from "styled-components";
 
+const ModalArea = styled.div`
+  width: 20rem;
+  height: 20rem;
+  z-index: 999;
+  position: absolute;
+  right: 0;
+  top: 4rem;
+  border-radius: 7px;
+  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
+
+  &.isHide {
+    display: none;
+  }
+
+  &.isShow {
+    display: block;
+  }
+`;
 export default function UserProfile() {
-  return <div>UserProfile</div>;
+  return <ModalArea><div>UserProfile</div></ModalArea>;
 }

--- a/src/components/modal/UserProfileModal.tsx
+++ b/src/components/modal/UserProfileModal.tsx
@@ -1,6 +1,19 @@
 import React from "react";
 import { ModalArea } from "../layout/ModalCommonLayout";
 
+const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  // 모달 컴포넌트 영역 클릭시 클릭 이벤트가 부모로 전달되어 컴포넌트가 닫히는 현상 수정
+  event.stopPropagation()
+}
+
 export default function UserProfile() {
-  return <ModalArea><div>UserProfile</div></ModalArea>;
+  return (
+    <ModalArea
+      $dynamicWidth=""
+      $dynamicHeight=""
+      onClick={handleClick}
+    >
+      <div>UserProfile</div>
+    </ModalArea>
+  );
 }

--- a/src/components/modal/UserProfileModal.tsx
+++ b/src/components/modal/UserProfileModal.tsx
@@ -1,24 +1,6 @@
 import React from "react";
-import { styled } from "styled-components";
+import { ModalArea } from "../layout/ModalCommonLayout";
 
-const ModalArea = styled.div`
-  width: 20rem;
-  height: 20rem;
-  z-index: 999;
-  position: absolute;
-  right: 0;
-  top: 4rem;
-  border-radius: 7px;
-  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.3);
-
-  &.isHide {
-    display: none;
-  }
-
-  &.isShow {
-    display: block;
-  }
-`;
 export default function UserProfile() {
   return <ModalArea><div>UserProfile</div></ModalArea>;
 }


### PR DESCRIPTION
### ⛳️ Task

- [x] 공통 레이아웃 내 컴포넌트 각 모달으로 이동시키기
- [x] 헤더 높이 수정

### ✍️ Note

- 현재 헤더 공통 레이아웃인 ModalCommonLayout.tsx 내에 위치한 ModalArea 컴포넌트를 각 모달 안에 위치시켜, 모달들 안에서 자유롭게 너비와 높이 값 등을 활용한 스타일링이 가능한 구조로 변경합니다.
- 기존 헤더의 높이가 9vh로 지정되어 있는 부분을 4rem으로 수정합니다. 
### 📸 Screenshot

![image](https://github.com/wowba/Calit/assets/62874043/40892a8f-cf23-4f2d-b62e-ba24069b40f2)

- 이전에는 해당 컴포넌트가 헤더 공통 레이아웃에 포함되어, 각 모달마다 크기와 너비 등의 스타일링 및 커스텀이 어려운 구조였습니다.
- 해당 컴포넌트를 각 모달 안으로 이동시켜, 모달마다 각자의 컨텐츠를 포함시켰을 때 자유롭게 커스텀 가능하게 변경하였습니다. 

### 📎 Reference

close #53 
