### PR TITLE
[#55] design : input common layout 생성

### DIFF
--- a/src/components/layout/InputCommonLayout.tsx
+++ b/src/components/layout/InputCommonLayout.tsx
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+interface InputProps {
+  $dynamicWidth: string;
+  $dynamicMargin?: string;
+  $dynamicColor?: string;
+}
+
+const InputCommon = styled.input<InputProps>`
+  width: ${(props) => props.$dynamicWidth};
+  border: 0.2px solid #ededed;
+  -webkit-border-radius: 4px;
+  padding: 0 8px;
+  background: ${(props) =>
+    props.$dynamicColor ? props.$dynamicColor : "#fafafa"};
+  margin: ${(props) => (props.$dynamicMargin ? props.$dynamicMargin : "2px")};
+`;
+
+export default InputCommon;

--- a/src/pages/ProjectListPage/ProjectCard.tsx
+++ b/src/pages/ProjectListPage/ProjectCard.tsx
@@ -4,6 +4,7 @@ import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
 import { db } from "../../firebaseSDK";
 import rectangle from "../../assets/images/Rectangle.svg";
 import ProjectIconContainer from "./ProjectIconContainer";
+import InputCommon from "../../components/layout/InputCommonLayout";
 
 interface Props {
   $dynamic_url?: string;
@@ -70,21 +71,16 @@ const ProjectCardName = styled.p`
   font-weight: 700;
   cursor: pointer;
 `;
-const ProjectCardNameInput = styled.input`
+const ProjectCardNameInput = styled(InputCommon)<{ $dynamicWidth: string }>`
+  width: ${(props) => props.$dynamicWidth};
   position: absolute;
   top: -28px;
   z-index: 1;
   left: 30px;
-  width: 160px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: 700;
-  border: none;
-  -webkit-border-radius: 4px;
-  padding: 0 8px;
-  background: #fafafa;
-  margin: 2px;
 `;
 
 const ProjectCardIntro = styled.p`
@@ -99,18 +95,13 @@ const ProjectCardIntro = styled.p`
   top: 10px;
 `;
 
-const ProjectCardIntroInput = styled.input`
-  width: 99%;
+const ProjectCardIntroInput = styled(InputCommon)<{ $dynamicWidth: string }>`
+  width: ${(props) => props.$dynamicWidth};
   height: 70px;
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  border: none;
-  -webkit-border-radius: 4px;
-  padding: 0 8px;
-  background: #fafafa;
-  margin: 2px;
   position: relative;
   top: -20px;
 `;
@@ -162,6 +153,7 @@ export default function ProjectCard({
       <ProjectCardInfo className="project-card-info">
         {isNameChangeable ? (
           <ProjectCardNameInput
+            $dynamicWidth="160px"
             value={inputNameValue}
             onChange={(e) => setInputNameValue(e.target.value)}
             onKeyDown={handleEnterPress}
@@ -178,6 +170,7 @@ export default function ProjectCard({
         />
         {isIntroChangeable ? (
           <ProjectCardIntroInput
+            $dynamicWidth="99%"
             value={inputIntroValue}
             onChange={(e) => setInputIntroValue(e.target.value)}
             onKeyDown={handleEnterPress}


### PR DESCRIPTION
### ⛳️ Task

- [x] 인풋 공통 레이아웃 생성

### ✍️ Note
- 기본적인 것만 세팅해두어서 이후 수정해도 됩니다!
- 사용방법 예시
```
const ProjectCardNameInput = styled(InputCommon)<{ $dynamicWidth: string }>
 width: ${(props) => props.$dynamicWidth};
//추가 속성
  position: absolute;
  top: -28px;
```

### 📸 Screenshot

### 📎 Reference

close #55