### PR TITLE
[#59] feat : ProjectCheckRoute 기능 추가

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import styled from "styled-components";
+import { useRecoilValue } from "recoil";
 
 import RobotoRegular from "../assets/fonts/Roboto-Regular.ttf";
 import trashIcon from "../assets/icons/trashIcon.svg";
 import sidebarTestImg from "../assets/images/sidebarTestImg.png";
+import projectState from "../recoil/atoms/project/projectState";
 
 const SidebarLayout = styled.div`
   display: flex;
@@ -59,10 +61,11 @@ const TrashBoxImg = styled.img`
 `;
 
 export default function Sidebar() {
+  const { projectData } = useRecoilValue(projectState);
   return (
     <SidebarLayout>
       <ProjectInfoBox>
-        <ProjectTitleParagraph>프로젝트 이름</ProjectTitleParagraph>
+        <ProjectTitleParagraph>{projectData.name}</ProjectTitleParagraph>
         <ProjectProfileImg src={sidebarTestImg} alt="Project Profile Img" />
       </ProjectInfoBox>
 

--- a/src/components/routes/ProjectCheckRoute.tsx
+++ b/src/components/routes/ProjectCheckRoute.tsx
@@ -1,8 +1,12 @@
-import React from "react";
-import { Outlet } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { doc, onSnapshot } from "firebase/firestore";
 import styled from "styled-components";
+import { useSetRecoilState } from "recoil";
 
 import Sidebar from "../Sidebar";
+import { db } from "../../firebaseSDK";
+import projectState from "../../recoil/atoms/project/projectState";
 
 const ProjectLayout = styled.div`
   display: flex;
@@ -10,10 +14,31 @@ const ProjectLayout = styled.div`
 `;
 
 export default function ProjectCheckRoute() {
-  return (
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const [isLoaded, setIsLoaded] = useState(false);
+  const setProjectDataState = useSetRecoilState(projectState);
+
+  useEffect(() => {
+    const projectRef = doc(db, "project", pathname);
+    const unsub = onSnapshot(projectRef, (projectDoc) => {
+      if (projectDoc.exists()) {
+        setIsLoaded(true);
+        setProjectDataState({
+          projectData: projectDoc.data(),
+        });
+      } else {
+        unsub();
+        navigate("/");
+      }
+    });
+    return () => unsub();
+  }, [pathname]);
+
+  return isLoaded === true ? (
     <ProjectLayout>
       <Sidebar />
       <Outlet />
     </ProjectLayout>
-  );
+  ) : null;
 }

--- a/src/components/routes/ProjectCheckRoute.tsx
+++ b/src/components/routes/ProjectCheckRoute.tsx
@@ -22,7 +22,7 @@ export default function ProjectCheckRoute() {
   useEffect(() => {
     const projectRef = doc(db, "project", pathname);
     const unsub = onSnapshot(projectRef, (projectDoc) => {
-      if (projectDoc.exists()) {
+      if (projectDoc.exists() && !projectDoc.data().is_deleted) {
         setIsLoaded(true);
         setProjectDataState({
           projectData: projectDoc.data(),

--- a/src/recoil/atoms/project/projectState.ts
+++ b/src/recoil/atoms/project/projectState.ts
@@ -1,0 +1,23 @@
+import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
+
+interface ProjectStateDefault {
+  projectData: unknown;
+}
+
+const defaultValue: ProjectStateDefault = {
+  projectData: null,
+};
+
+const { persistAtom } = recoilPersist({
+  key: "localStorage",
+  storage: localStorage,
+});
+
+const projectState = atom({
+  key: "projectData",
+  default: defaultValue,
+  effects_UNSTABLE: [persistAtom],
+});
+
+export default projectState;

--- a/src/recoil/atoms/project/projectState.ts
+++ b/src/recoil/atoms/project/projectState.ts
@@ -1,23 +1,16 @@
 import { atom } from "recoil";
-import { recoilPersist } from "recoil-persist";
 
 interface ProjectStateDefault {
-  projectData: unknown;
+  projectData: any;
 }
 
 const defaultValue: ProjectStateDefault = {
   projectData: null,
 };
 
-const { persistAtom } = recoilPersist({
-  key: "localStorage",
-  storage: localStorage,
-});
-
 const projectState = atom({
   key: "projectData",
   default: defaultValue,
-  effects_UNSTABLE: [persistAtom],
 });
 
 export default projectState;


### PR DESCRIPTION
### ⛳️ Task

- [x] ProjectCheckRoute.tsx 기능 추가
  - 이제 존재하지 않거나 (문서 key) 삭제된 프로젝트 (is_deleted)를 url에 입력시 useNavigate 훅을 이용해 프로젝트 리스트 페이지로 돌아가도록 만들었습니다. 
  - 이후에 404 페이지가 제작된다면 해당 페이지로 navigate해도 좋을 것 같아요!
  - 기존에 Login.tsx에서 유저 정보를 recoil에 저장하기 전에 프로젝트 리스트 페이지로 이동하여 에러가 발생한 것에서 착안하여
     useEffect 훅 내에서 비동기 작업이 완료되지 않을 경우 null 을 렌더링하고, recoil 저장 이후 프로젝트 페이지로 이동하도록 작업했습니다.
     하지만 projectState는 localStorage에 값을 저장하지 않기 때문에 좀 기우인 듯 합니다...
     - useEffect 훅 내에는 onSnapshot 메서드를 실행해 projectState를 최신화하고 있습니다!
- [x] projectState.ts 추가
  - 실시간으로 프로젝트 데이터를 저장하는 projectState를 추가했습니다.
  - 현재 any타입으로 데이터를 받아오고 있지만, 이후에 FireStroe에서 받아오는 데이터를 TS로 정리하면 좋을 듯 합니다!
 - [x] Sidebar.tsx 프로젝트 이름 추가
   - 사용 예시를 보여드리기 위해 Sidebar.tsx 에서 projectState를 받아와 사용하는 예시를 추가했습니다. 

### ✍️ Note

### 📸 Screenshot

### 📎 Reference

close #59 