### PR TITLE
[#61] feat & design : 달력 드래그 시 칸반 생성 모달 팝업기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fullcalendar/core": "^6.1.9",
         "@fullcalendar/daygrid": "^6.1.9",
+        "@fullcalendar/interaction": "^6.1.9",
         "@fullcalendar/react": "^6.1.9",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -3020,6 +3021,14 @@
       "version": "6.1.9",
       "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.9.tgz",
       "integrity": "sha512-o/6joH/7lmVHXAkbaa/tUbzWYnGp/LgfdiFyYPkqQbjKEeivNZWF1WhHqFbhx0zbFONSHtrvkjY2bjr+Ef2quQ==",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.9"
+      }
+    },
+    "node_modules/@fullcalendar/interaction": {
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.9.tgz",
+      "integrity": "sha512-I3FGnv0kKZpIwujg3HllbKrciNjTqeTYy3oJG226oAn7lV6wnrrDYMmuGmA0jPJAGN46HKrQqKN7ItxQRDec4Q==",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.9"
       }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@fullcalendar/core": "^6.1.9",
     "@fullcalendar/daygrid": "^6.1.9",
+    "@fullcalendar/interaction": "^6.1.9",
     "@fullcalendar/react": "^6.1.9",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
@@ -1,7 +1,10 @@
-import React from "react";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React, { useState } from "react";
+import { DateSelectArg } from "@fullcalendar/core";
 import styled from "styled-components";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin from "@fullcalendar/interaction";
 
 import {
   ProjectModalLayout,
@@ -10,6 +13,7 @@ import {
   ProjectModalTabBox,
   ProjectModalContentBox,
 } from "../../../components/layout/ProjectModalLayout";
+import CreateKanbanModal from "./CreateKanbanModal";
 
 const CalendarBox = styled.div`
   height: 100%;
@@ -194,8 +198,28 @@ type Props = {
 };
 
 export default function CalendarModal({ calendarTabColor }: Props) {
-  const setting = {
-    plugins: [dayGridPlugin],
+  const [isShowCreateKanbanModal, setIsShowCreateKanbanModal] = useState(false);
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  const handleSelect = (info: DateSelectArg) => {
+    const calendarApi = info.view.calendar;
+    setStartDate(info.startStr);
+    setEndDate(info.endStr);
+    setIsShowCreateKanbanModal(true);
+    // calendarApi.addEvent({
+    //   id: "1",
+    //   title: "칸반",
+    //   start: info.startStr,
+    //   end: info.endStr,
+    //   allDay: info.allDay,
+    // });
+    calendarApi.unselect();
+  };
+
+  const fullCalendarSetting = {
+    plugins: [dayGridPlugin, interactionPlugin],
+    selectable: true,
     headerToolbar: {
       left: "today",
       center: "prev title next",
@@ -212,6 +236,7 @@ export default function CalendarModal({ calendarTabColor }: Props) {
       // 버튼 텍스트 변환
       today: "오늘",
     },
+    select: handleSelect,
   };
 
   return (
@@ -226,9 +251,15 @@ export default function CalendarModal({ calendarTabColor }: Props) {
         <CalendarBox>
           <FullCalendar
             // eslint-disable-next-line react/jsx-props-no-spreading
-            {...setting}
+            {...fullCalendarSetting}
           />
         </CalendarBox>
+        <CreateKanbanModal
+          isShow={isShowCreateKanbanModal}
+          setIsShow={setIsShowCreateKanbanModal}
+          startDate={startDate}
+          endDate={endDate}
+        />
       </ProjectModalContentBox>
     </ProjectModalLayout>
   );

--- a/src/pages/ProjectPage/CalendarModal/CreateKanbanModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CreateKanbanModal.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import styled, { css } from "styled-components";
+
+import { useLocation } from "react-router-dom";
+import { serverTimestamp } from "firebase/firestore";
+import { createKanban } from "../../../api/CreateCollection";
+import ConfirmBtn from "../../../components/layout/ConfirmBtnLayout";
+
+const CreateKanbanModalLayout = styled.div<{ $isShow: boolean }>`
+  position: fixed;
+
+  top: calc((100% + 2rem) / 2);
+  left: calc((100% + 12rem) / 2);
+  transform: translate(-50%, -50%);
+
+  width: 40rem;
+  height: 25rem;
+  border-radius: 0.9rem;
+  box-shadow: 0px 0px 10px 6px rgba(0, 0, 0, 0.3);
+  background-color: white;
+  padding: 2.5rem 2.5rem 2.5rem 2.5rem;
+
+  z-index: 999;
+
+  ${(props) =>
+    !props.$isShow &&
+    css`
+      display: none;
+    `}
+`;
+
+const CreateKanbanModalTitleParagraph = styled.p`
+  font-size: 1.5rem;
+  font-weight: 700;
+`;
+
+const CreateKanbanModalInfoBox = styled.div`
+  display: flex;
+  gap: 2rem;
+
+  margin-top: 1.5rem;
+
+  & > p {
+    width: 10rem;
+    font-size: 1.125rem;
+    color: #969696;
+  }
+  & > span {
+    font-size: 1.125rem;
+  }
+`;
+
+const CreateKanbanModalBtnBox = styled.div`
+  display: flex;
+  justify-content: center;
+
+  gap: 2rem;
+  margin-top: 1.5rem;
+`;
+
+const CreateKanbanModalBackground = styled.button<{ $isShow: boolean }>`
+  position: fixed;
+
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: 100%;
+
+  background-color: transparent;
+  z-index: 998;
+
+  cursor: default;
+
+  ${(props) =>
+    !props.$isShow &&
+    css`
+      display: none;
+    `}
+`;
+
+interface Props {
+  isShow: boolean;
+  setIsShow: React.Dispatch<React.SetStateAction<boolean>>;
+  startDate: string;
+  endDate: string;
+}
+
+export default function CreateKanbanModal(props: Props) {
+  const location = useLocation();
+
+  const { isShow, setIsShow, startDate, endDate } = props;
+
+  const handleModalCloseClick = () => {
+    setIsShow(false);
+  };
+
+  const handleCreateBtnClick = async () => {
+    await createKanban(location.pathname, {
+      user_list: [],
+      stage_list: [],
+      name: "테스트칸반",
+      start_date: new Date(startDate),
+      end_date: new Date(endDate),
+      created_date: serverTimestamp(),
+      modified_date: serverTimestamp(),
+      is_deleted: false,
+    });
+    setIsShow(false);
+  };
+
+  return (
+    <>
+      <CreateKanbanModalLayout $isShow={isShow}>
+        <CreateKanbanModalTitleParagraph>
+          칸반 생성
+        </CreateKanbanModalTitleParagraph>
+        <CreateKanbanModalInfoBox>
+          <p>이름</p>
+          <span>칸반 이름</span>
+        </CreateKanbanModalInfoBox>
+        <CreateKanbanModalInfoBox>
+          <p>시작일</p>
+          <span>{startDate}</span>
+        </CreateKanbanModalInfoBox>
+        <CreateKanbanModalInfoBox>
+          <p>종료일</p>
+          <span>{endDate}</span>
+        </CreateKanbanModalInfoBox>
+        <CreateKanbanModalInfoBox>
+          <p>담당자</p>
+          <select>asdf</select>
+        </CreateKanbanModalInfoBox>
+        <CreateKanbanModalBtnBox>
+          <ConfirmBtn
+            $dynamicWidth="4rem"
+            $dynamicColor="#D0D0D0"
+            onClick={handleModalCloseClick}
+          >
+            취소
+          </ConfirmBtn>
+          <ConfirmBtn $dynamicWidth="4rem" onClick={handleCreateBtnClick}>
+            생성
+          </ConfirmBtn>
+        </CreateKanbanModalBtnBox>
+      </CreateKanbanModalLayout>
+      <CreateKanbanModalBackground
+        $isShow={isShow}
+        onClick={handleModalCloseClick}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
### ⛳️ Task

- [x] 달력 드래그 시 칸반 모달이 팝업됩니다.
  - 달력 상호작용을 위한 @fullcalendar/interaction 라이브러리를 설치했습니다.
  - 칸반 모달은 투명한 배경 컴포넌트를 가지고 있어 모달 외부 클릭시 자동으로 모달창이 사라집니다.
- [x] 칸반 생성 모달 내 정보 변경은 아직 미완성 입니다.
  - 생성 버튼 클릭시 임시로 작성한 칸반 문서가 생성됩니다. 
  - 아직 화면에 보여주는 로직은 없어 ProjectCheckRoute.tsx 기능 추가 이후 작업 할 예정입니다.

### ✍️ Note

### 📸 Screenshot

### 📎 Reference

close #61 