### PR TITLE
[#72] feat : 드래그로 칸반 생성 및 칸반 컬렉션 실시간 연동 추가

### DIFF
--- a/src/api/CreateCollection.tsx
+++ b/src/api/CreateCollection.tsx
@@ -21,6 +21,7 @@ interface TodoData {
   is_deleted: boolean;
   stageID: string;
   deadline: Date;
+  info: string;
 }
 
 export const createKanban = async (

--- a/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { DateSelectArg } from "@fullcalendar/core";
 import styled from "styled-components";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
+import { useRecoilValue } from "recoil";
 
 import {
   ProjectModalLayout,
@@ -14,6 +14,8 @@ import {
   ProjectModalContentBox,
 } from "../../../components/layout/ProjectModalLayout";
 import CreateKanbanModal from "./CreateKanbanModal";
+import kanbanState from "../../../recoil/atoms/kanban/kanbanState";
+import yearMonthDayFormat from "../../../utils/yearMonthDayFormat";
 
 const CalendarBox = styled.div`
   height: 100%;
@@ -198,22 +200,29 @@ type Props = {
 };
 
 export default function CalendarModal({ calendarTabColor }: Props) {
+  const kanbanDataState = useRecoilValue(kanbanState);
   const [isShowCreateKanbanModal, setIsShowCreateKanbanModal] = useState(false);
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
+
+  const [kanbanEvents, setKanbanEvents] = useState(Array<any>);
+
+  useEffect(() => {
+    const data = [...kanbanDataState];
+    const result = data.map((item) => ({
+      id: item[0],
+      start: yearMonthDayFormat(item[1].start_date.seconds),
+      end: yearMonthDayFormat(item[1].end_date.seconds),
+      title: item[1].name,
+    }));
+    setKanbanEvents(result);
+  }, [kanbanDataState]);
 
   const handleSelect = (info: DateSelectArg) => {
     const calendarApi = info.view.calendar;
     setStartDate(info.startStr);
     setEndDate(info.endStr);
     setIsShowCreateKanbanModal(true);
-    // calendarApi.addEvent({
-    //   id: "1",
-    //   title: "칸반",
-    //   start: info.startStr,
-    //   end: info.endStr,
-    //   allDay: info.allDay,
-    // });
     calendarApi.unselect();
   };
 
@@ -236,6 +245,7 @@ export default function CalendarModal({ calendarTabColor }: Props) {
       // 버튼 텍스트 변환
       today: "오늘",
     },
+    events: kanbanEvents,
     select: handleSelect,
   };
 

--- a/src/pages/ProjectPage/CalendarModal/CreateKanbanModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CreateKanbanModal.tsx
@@ -3,7 +3,7 @@ import styled, { css } from "styled-components";
 
 import { useLocation } from "react-router-dom";
 import { serverTimestamp } from "firebase/firestore";
-import { createKanban } from "../../../api/CreateCollection";
+import { createKanban, createTodo } from "../../../api/CreateCollection";
 import ConfirmBtn from "../../../components/layout/ConfirmBtnLayout";
 
 const CreateKanbanModalLayout = styled.div<{ $isShow: boolean }>`
@@ -96,7 +96,7 @@ export default function CreateKanbanModal(props: Props) {
   };
 
   const handleCreateBtnClick = async () => {
-    await createKanban(location.pathname, {
+    const kanbanID = await createKanban(location.pathname, {
       user_list: [],
       stage_list: [],
       name: "테스트칸반",
@@ -105,6 +105,18 @@ export default function CreateKanbanModal(props: Props) {
       created_date: serverTimestamp(),
       modified_date: serverTimestamp(),
       is_deleted: false,
+    });
+    await createTodo(location.pathname, kanbanID, {
+      update_list: [],
+      user_list: [],
+      name: "dummyTodo",
+      order: -1,
+      created_date: serverTimestamp(),
+      modified_date: serverTimestamp(),
+      is_deleted: true,
+      stageID: "dummyTodo",
+      deadline: new Date(),
+      info: "dummy",
     });
     setIsShow(false);
   };

--- a/src/recoil/atoms/kanban/kanbanState.ts
+++ b/src/recoil/atoms/kanban/kanbanState.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const kanbanState = atom({
+  key: "kanbanData",
+  default: new Map(),
+});
+
+export default kanbanState;

--- a/src/utils/yearMonthDayFormat.ts
+++ b/src/utils/yearMonthDayFormat.ts
@@ -1,0 +1,11 @@
+export default function yearMonthDayFormat(seconds: number) {
+  const formatDate = new Date(seconds * 1000);
+
+  let month: number | string = formatDate.getMonth() + 1;
+  let day: number | string = formatDate.getDate();
+
+  month = month >= 10 ? month : `0${month}`;
+  day = day >= 10 ? day : `0${day}`;
+
+  return `${formatDate.getFullYear()}-${month}-${day}`;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
### ⛳️ Task

- [x] ProjectCheckRoute.tsx 에서 실시간으로 프로젝트의 하위 컬렉션 kanban의 문서를 가져옵니다.
  - 실시간으로 관리되는 kanban 문서는 캘린더 모달에서 확인할 수 있습니다.
  - 전역적으로 관리하기 위해 kanbanState.ts 를 이용합니다.
- [x] YYYY-MM-DD 형태로 timeStamp를 변환하는 yearMonthDayFormat.ts 공통함수를 만들었습니다.
  - 사용 시 timeStamp.second를 인자로 받으면 함수 내에서 *1000 하여 변환값을 반환합니다.
- [x] ES6의 Map을 사용하기 위해 tsconfig.json 의 target을 es6로 변경했습니다.
- [x] 칸반 생성시 투두 컬렉션 및 더미 투두를 생성합니다. (프로젝트 생성시 더미 칸반을 생성하는 것과 동일한 로직)
- [x] CreateCollection 의 Todo interface에서 info 필드를 추가했습니다. 

### ✍️ Note

### 📸 Screenshot

### 📎 Reference

close #72 