### PR TITLE
[#82] feat : 달력 칸반 클릭시 칸반 모달 팝업

### DIFF
--- a/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { DateSelectArg } from "@fullcalendar/core";
+import { DateSelectArg, EventClickArg } from "@fullcalendar/core";
 import styled from "styled-components";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import { useRecoilValue } from "recoil";
 
+import { SetURLSearchParams } from "react-router-dom";
 import {
   ProjectModalLayout,
   ProjectModalTabBackground,
@@ -197,9 +198,13 @@ const CalendarBox = styled.div`
 
 type Props = {
   calendarTabColor: string;
+  setSearchParams: SetURLSearchParams;
 };
 
-export default function CalendarModal({ calendarTabColor }: Props) {
+export default function CalendarModal({
+  calendarTabColor,
+  setSearchParams,
+}: Props) {
   const kanbanDataState = useRecoilValue(kanbanState);
   const [isShowCreateKanbanModal, setIsShowCreateKanbanModal] = useState(false);
   const [startDate, setStartDate] = useState(new Date());
@@ -226,6 +231,12 @@ export default function CalendarModal({ calendarTabColor }: Props) {
     calendarApi.unselect();
   };
 
+  const handleEventClick = (eventArg: EventClickArg) => {
+    const { event } = eventArg;
+    const { _def: eventInfo } = event;
+    setSearchParams({ kanbanID: eventInfo.publicId });
+  };
+
   const fullCalendarSetting = {
     plugins: [dayGridPlugin, interactionPlugin],
     selectable: true,
@@ -248,6 +259,7 @@ export default function CalendarModal({ calendarTabColor }: Props) {
     fixedWeekCount: false,
     events: kanbanEvents,
     select: handleSelect,
+    eventClick: handleEventClick,
   };
 
   return (

--- a/src/pages/ProjectPage/Project.tsx
+++ b/src/pages/ProjectPage/Project.tsx
@@ -29,7 +29,7 @@ const ProjectLayoutFooter = styled.div`
 `;
 
 export default function Project() {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   let calendarTabColor = "#FFD43B";
   let kanbanTabColor = "#ffea7a";
@@ -52,7 +52,10 @@ export default function Project() {
   return (
     <ProjectLayout>
       {/* 캘린더 */}
-      <CalendarModal calendarTabColor={calendarTabColor} />
+      <CalendarModal
+        calendarTabColor={calendarTabColor}
+        setSearchParams={setSearchParams}
+      />
       {/* 칸반 */}
       <KanbanModal
         kanbanTabColor={kanbanTabColor}


### PR DESCRIPTION
### ⛳️ Task

- [x] 달력 칸반 클릭시 칸반 모달 팝업 기능 추가
  - Project.tsx 컴포넌트에서 setSeatchParams을 CalendarModal의 Prop으로 넣어서 칸반 클릭시 queryString을 업데이트 합니다.
  - queryString이 업데이트 되면 Project.tsx 컴포넌트가 리렌더링 되면서 KanbanModal의 isShow가 업데이트 되어 팝업됩니다!

### ✍️ Note

### 📸 Screenshot

### 📎 Reference

close #82 