### PR TITLE
[#85] feat : 칸반 색상 할당 / 드래그, 리사이즈 이벤트 추가

### DIFF
--- a/src/api/CreateCollection.tsx
+++ b/src/api/CreateCollection.tsx
@@ -10,6 +10,7 @@ interface KanbanData {
   created_date: FieldValue;
   modified_date: FieldValue;
   is_deleted: boolean;
+  color: string;
 }
 interface TodoData {
   update_list: Array<Object>;

--- a/src/pages/ProjectListPage/CreateProjectBtn.tsx
+++ b/src/pages/ProjectListPage/CreateProjectBtn.tsx
@@ -70,6 +70,7 @@ export default function CreateProjectBtn() {
       modified_date: serverTimestamp(),
       name: "dummyKanban",
       is_deleted: true,
+      color: "#3888d8",
     });
     // 유저의 project_list 업데이트
     if (userCredential) {

--- a/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
@@ -1,12 +1,20 @@
 import React, { useEffect, useState } from "react";
-import { DateSelectArg, EventClickArg } from "@fullcalendar/core";
+import {
+  DateSelectArg,
+  EventClickArg,
+  CalendarOptions,
+  EventDropArg,
+} from "@fullcalendar/core";
 import styled from "styled-components";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
-import interactionPlugin from "@fullcalendar/interaction";
+import interactionPlugin, {
+  EventResizeDoneArg,
+} from "@fullcalendar/interaction";
 import { useRecoilValue } from "recoil";
-
+import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
 import { SetURLSearchParams } from "react-router-dom";
+
 import {
   ProjectModalLayout,
   ProjectModalTabBackground,
@@ -17,6 +25,9 @@ import {
 import CreateKanbanModal from "./CreateKanbanModal";
 import kanbanState from "../../../recoil/atoms/kanban/kanbanState";
 import yearMonthDayFormat from "../../../utils/yearMonthDayFormat";
+import { db } from "../../../firebaseSDK";
+import getTextColorByBackgroundColor from "../../../utils/getTextColorByBgColor";
+import getBorderColorByBackgroundColor from "../../../utils/getBorderColorByBgColor";
 
 const CalendarBox = styled.div`
   height: 100%;
@@ -219,6 +230,9 @@ export default function CalendarModal({
       start: yearMonthDayFormat(item[1].start_date.seconds),
       end: yearMonthDayFormat(item[1].end_date.seconds),
       title: item[1].name,
+      backgroundColor: item[1].color,
+      textColor: getTextColorByBackgroundColor(item[1].color),
+      borderColor: getBorderColorByBackgroundColor(item[1].color),
     }));
     setKanbanEvents(result);
   }, [kanbanDataState]);
@@ -232,12 +246,57 @@ export default function CalendarModal({
   };
 
   const handleEventClick = (eventArg: EventClickArg) => {
-    const { event } = eventArg;
-    const { _def: eventInfo } = event;
+    const {
+      event: { _def: eventInfo },
+    } = eventArg;
     setSearchParams({ kanbanID: eventInfo.publicId });
   };
 
-  const fullCalendarSetting = {
+  const handleEventDrop = async (eventArg: EventDropArg) => {
+    // eslint-disable-next-line no-underscore-dangle
+    const { start, end } = eventArg.event._instance!.range;
+
+    const {
+      event: { _def: eventInfo },
+    } = eventArg;
+
+    const kanbanRef = doc(
+      db,
+      "project",
+      window.location.pathname,
+      "kanban",
+      eventInfo.publicId,
+    );
+    await updateDoc(kanbanRef, {
+      start_date: start,
+      end_date: end,
+      modified_date: serverTimestamp(),
+    });
+  };
+
+  const handleEventResize = async (eventArg: EventResizeDoneArg) => {
+    // eslint-disable-next-line no-underscore-dangle
+    const { end } = eventArg.event._instance!.range;
+
+    const {
+      event: { _def: eventInfo },
+    } = eventArg;
+
+    const kanbanRef = doc(
+      db,
+      "project",
+      window.location.pathname,
+      "kanban",
+      eventInfo.publicId,
+    );
+
+    await updateDoc(kanbanRef, {
+      end_date: end,
+      modified_date: serverTimestamp(),
+    });
+  };
+
+  const fullCalendarSetting: CalendarOptions = {
     plugins: [dayGridPlugin, interactionPlugin],
     selectable: true,
     headerToolbar: {
@@ -253,13 +312,15 @@ export default function CalendarModal({
     initialView: "dayGridMonth",
     locale: "ko",
     buttonText: {
-      // 버튼 텍스트 변환
       today: "오늘",
     },
+    editable: true,
     fixedWeekCount: false,
     events: kanbanEvents,
     select: handleSelect,
     eventClick: handleEventClick,
+    eventDrop: handleEventDrop,
+    eventResize: handleEventResize,
   };
 
   return (

--- a/src/pages/ProjectPage/CalendarModal/CreateKanbanModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CreateKanbanModal.tsx
@@ -17,7 +17,7 @@ const CreateKanbanModalLayout = styled.div<{ $isShow: boolean }>`
   transform: translate(-50%, -50%);
 
   width: 40rem;
-  height: 25rem;
+  height: auto;
   border-radius: 0.9rem;
   box-shadow: 0px 0px 10px 6px rgba(0, 0, 0, 0.3);
   background-color: white;
@@ -100,12 +100,30 @@ export default function CreateKanbanModal(props: Props) {
     props;
   const [kanbanName, setKanbanName] = useState("");
   const [userList, setUserList] = useState<any[]>([]);
+  const [color, setColor] = useState("#3888d8");
+
+  const resetCreateKanbanModalState = () => {
+    setUserList([]);
+    setKanbanName("");
+    setColor("#3888d8");
+    setIsShow(false);
+  };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setKanbanName(e.target.value);
   };
 
   const handleCreateBtnClick = async () => {
+    if (!kanbanName) {
+      // eslint-disable-next-line no-alert
+      alert("칸반 제목을 입력해 주세요.");
+      return false;
+    }
+    if (userList.length === 0) {
+      // eslint-disable-next-line no-alert
+      alert("담당자를 최소 한 명 이상 할당해주세요.");
+      return false;
+    }
     const kanbanID = await createKanban(location.pathname, {
       user_list: userList,
       stage_list: [],
@@ -115,6 +133,7 @@ export default function CreateKanbanModal(props: Props) {
       created_date: serverTimestamp(),
       modified_date: serverTimestamp(),
       is_deleted: false,
+      color,
     });
     await createTodo(location.pathname, kanbanID, {
       update_list: [],
@@ -128,13 +147,12 @@ export default function CreateKanbanModal(props: Props) {
       deadline: new Date(),
       info: "dummy",
     });
-    setIsShow(false);
+    resetCreateKanbanModalState();
+    return true;
   };
 
   const handleModalCloseClick = () => {
-    setUserList([]);
-    setKanbanName("");
-    setIsShow(false);
+    resetCreateKanbanModalState();
   };
 
   return (
@@ -153,6 +171,16 @@ export default function CreateKanbanModal(props: Props) {
             $dynamicPadding="0.25rem 0.25rem 0.25rem 0.25rem"
             $dynamicWidth="20rem"
             $isHover
+          />
+        </CreateKanbanModalInfoBox>
+        <CreateKanbanModalInfoBox>
+          <p>색상</p>
+          <input
+            type="color"
+            value={color}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setColor(e.target.value)
+            }
           />
         </CreateKanbanModalInfoBox>
         <CreateKanbanModalInfoBox>
@@ -185,7 +213,7 @@ export default function CreateKanbanModal(props: Props) {
             userList={userList}
             setUserList={setUserList}
             // eslint-disable-next-line no-console
-            onBlur={() => console.log(userList)}
+            onBlur={() => false}
           />
         </CreateKanbanModalInfoBox>
         <CreateKanbanModalBtnBox>

--- a/src/utils/getBorderColorByBgColor.ts
+++ b/src/utils/getBorderColorByBgColor.ts
@@ -1,0 +1,13 @@
+/* eslint-disable no-bitwise */
+export default function getBorderColorByBackgroundColor(hexColor: string) {
+  const c = hexColor.substring(1); // 색상 앞의 # 제거
+  const rgb = parseInt(c, 16); // rrggbb를 10진수로 변환
+  const r = (rgb >> 16) & 0xff; // red 추출
+  const g = (rgb >> 8) & 0xff; // green 추출
+  const b = (rgb >> 0) & 0xff; // blue 추출
+
+  const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b; // per ITU-R BT.709
+
+  // 색상 선택
+  return luma < 127.5 ? "transparent" : "gray";
+}

--- a/src/utils/getTextColorByBgColor.ts
+++ b/src/utils/getTextColorByBgColor.ts
@@ -1,0 +1,13 @@
+/* eslint-disable no-bitwise */
+export default function getTextColorByBackgroundColor(hexColor: string) {
+  const c = hexColor.substring(1); // 색상 앞의 # 제거
+  const rgb = parseInt(c, 16); // rrggbb를 10진수로 변환
+  const r = (rgb >> 16) & 0xff; // red 추출
+  const g = (rgb >> 8) & 0xff; // green 추출
+  const b = (rgb >> 0) & 0xff; // blue 추출
+
+  const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b; // per ITU-R BT.709
+
+  // 색상 선택
+  return luma < 127.5 ? "white" : "black";
+}


### PR DESCRIPTION
### ⛳️ Task

- [x] 칸반 생성 모달에 색상 선택을 추가했습니다.
  - 배경색에 따라 칸반의 border, font 색상이 동적으로 결정됩니다.
  - 이름 혹은 담당자를 선택하지 않을시 경고창이 팝업됩니다.
  - kanban의 인터페이스에 color 항목을 추가했습니다.
- [x] 칸반 드래그 혹은 리사이징 시 이제 업데이트가 가능해졌습니다.

### ✍️ Note

### 📸 Screenshot

### 📎 Reference

close #85 