### PR TITLE
feat : todo 담당자 추가/수정/삭제

### DIFF
--- a/src/components/layout/CommonSelectMemberLayout.tsx
+++ b/src/components/layout/CommonSelectMemberLayout.tsx
@@ -49,12 +49,12 @@ export default function CommonSelectMemberLayout(props: Props) {
         }),
       );
       setUserData(data);
-      if (userList) {
-        const filteredValue = data.filter((user) =>
-          userList.includes(user.value),
-        );
-        setUserList(filteredValue);
-      }
+      // if (userList) {
+      //   const filteredValue = data.filter((user) =>
+      //     userList.includes(user.value),
+      //   );
+      //   setUserList(filteredValue);
+      // }
     };
 
     fetchData();

--- a/src/components/layout/CommonSelectMemberLayout.tsx
+++ b/src/components/layout/CommonSelectMemberLayout.tsx
@@ -49,12 +49,6 @@ export default function CommonSelectMemberLayout(props: Props) {
         }),
       );
       setUserData(data);
-      // if (userList) {
-      //   const filteredValue = data.filter((user) =>
-      //     userList.includes(user.value),
-      //   );
-      //   setUserList(filteredValue);
-      // }
     };
 
     fetchData();


### PR DESCRIPTION
### ⛳️ Task

### ✍️ Note
- CommonSelectMemberLayout 을 활용해 담당자 추가/ 수정/ 삭제 기능을 완성했습니다.
- 기존에 존재하던 담당자 삭제 기능은 삭제했습니다.
- 해결된 이슈)
 : firestore에서 받아온 userList가 초기에 정상적으로 가져왔다가 초기화되는 이슈가 있었습니다.
 : CommonSelectMemeberLayout 내에 filter를 통해 다시 setUserList를 해주는 부분을 제거해 해결했습니다. 

### 📸 Screenshot

### 📎 Reference
