### PR TITLE
[#94] design : 투두 페이지 레이아웃 수정 및 toolbar 보여짐 여부 설정

### DIFF
--- a/src/components/layout/CommonTextArea.tsx
+++ b/src/components/layout/CommonTextArea.tsx
@@ -2,15 +2,18 @@ import styled from "styled-components";
 
 interface Props {
   $dynamicWidth?: string;
+  $dynamicMaxHeight?: string;
   $dynamicRow?: string;
   $dynamicPadding?: string;
 }
 
 const CommonTextArea = styled.textarea<Props>`
   width: ${(props) => (props.$dynamicWidth ? props.$dynamicWidth : "100%")};
+  max-height: ${(props) =>
+    props.$dynamicMaxHeight ? props.$dynamicMaxHeight : "23rem"};
   rows: ${(props) => (props.$dynamicRow ? props.$dynamicRow : "1")};
   padding: ${(props) => (props.$dynamicPadding ? props.$dynamicPadding : "0")};
-  overflow: hidden;
+  overflow: scroll;
   border: 1px solid transparent;
   border-radius: 0.3rem;
   outline: none;

--- a/src/pages/ProjectPage/TodoModal/MarkdownEditor.tsx
+++ b/src/pages/ProjectPage/TodoModal/MarkdownEditor.tsx
@@ -15,9 +15,9 @@ const AddUpdateTitle = styled.div`
 `;
 const UpdateContainer = styled.div`
   background-color: #eaeaea;
-  height: auto;
+  height: 80%;
   overflow: scroll;
-  padding: 1.2rem;
+  padding: 1.2rem 1.2rem 0 1.2rem;
   border-radius: 10px;
   border: 0.5px solid #eaeaea;
 `;
@@ -63,7 +63,7 @@ export default function MarkdownEditor({ todoRef, todoDataState }: any) {
           <span
             style={{
               fontWeight: "900",
-              fontSize: "1.2rem",
+              fontSize: "0.9rem",
             }}
           >
             업데이트 등록
@@ -72,6 +72,8 @@ export default function MarkdownEditor({ todoRef, todoDataState }: any) {
             type="submit"
             onClick={handleSubmit}
             $dynamicWidth="3.5rem"
+            $dynamicHeight="2rem"
+            style={{ fontSize: "0.9rem" }}
           >
             등록
           </ConfirmBtn>
@@ -82,7 +84,7 @@ export default function MarkdownEditor({ todoRef, todoDataState }: any) {
         <span
           style={{
             fontWeight: "900",
-            fontSize: "1.2rem",
+            fontSize: "0.9rem",
             margin: "1.5rem 0 0",
             display: "inline-block",
           }}

--- a/src/pages/ProjectPage/TodoModal/TodoModal.tsx
+++ b/src/pages/ProjectPage/TodoModal/TodoModal.tsx
@@ -33,17 +33,18 @@ const TodoContainer = styled(ProjectModalContentBox)`
   padding: 2rem;
   display: grid;
   grid-template-columns: 1fr 1fr;
+  overflow: hidden;
 `;
 const TodoTitle = styled.div`
   display: inline-block;
   font-weight: 900;
-  font-size: 1.5rem;
+  font-size: 1.2rem;
   margin: 0 1rem 2rem 0;
 `;
 const TodoSubtitle = styled.div`
   display: inline-block;
   font-weight: 900;
-  font-size: 1.1rem;
+  font-size: 0.9rem;
   margin: 0 1rem 1rem 0;
 `;
 
@@ -195,13 +196,13 @@ export default function TodoModal({ todoTabColor, isTodoShow }: Props) {
         </ProjectModalTabText>
       </ProjectModalTabBox>
       <TodoContainer>
-        <div>
+        <div style={{ padding: "0 2rem 0 0" }}>
           <TodoTitle>
             <CommonInputLayout
               type="text"
               placeholder="제목을 입력하세요"
               value={inputTodoName}
-              $dynamicFontSize=" 1.5rem"
+              $dynamicFontSize=" 1.2rem"
               $dynamicPadding="1rem 0.5rem"
               $dynamicWidth="auto"
               // onKeyDown={handleEnterPress}

--- a/src/pages/ProjectPage/TodoModal/UpdateContent.tsx
+++ b/src/pages/ProjectPage/TodoModal/UpdateContent.tsx
@@ -30,7 +30,7 @@ const Contour = styled.div`
   margin: 0.5rem auto;
 `;
 const UpdateContent = styled.div`
-  margin: 1rem 0 2rem;
+  margin: 1rem 0 1rem;
   border-radius: 10px;
   background-color: white;
   padding: 1rem;
@@ -109,10 +109,11 @@ export default function UpdateContentBox({ todoRef, data, updateIndex }: any) {
             src={profileImgUrl}
             alt="프로필사진"
             style={{
-              width: "3rem",
-              height: "3rem",
+              width: "1.5rem",
+              height: "1.5rem",
               objectFit: "cover",
               borderRadius: "50%",
+              margin: "0 0.5rem 0 0",
             }}
           />
           {name}
@@ -154,11 +155,22 @@ export default function UpdateContentBox({ todoRef, data, updateIndex }: any) {
         </SettingContainer>
       </UpdateListHeader>
       <Contour />
-      <MDEditor
-        value={markdownContent}
-        onChange={handleMarkdownChange}
-        preview={isEditing ? "edit" : "preview"}
-      />
+      {isEditing ? (
+        <MDEditor
+          value={markdownContent}
+          onChange={handleMarkdownChange}
+          preview={isEditing ? "edit" : "preview"}
+          hideToolbar={false}
+        />
+      ) : (
+        <MDEditor
+          value={markdownContent}
+          onChange={handleMarkdownChange}
+          preview={isEditing ? "edit" : "preview"}
+          // eslint-disable-next-line react/jsx-boolean-value
+          hideToolbar={true}
+        />
+      )}
     </UpdateContent>
   );
 }


### PR DESCRIPTION
### ⛳️ Task

### ✍️ Note
- todo페이지에선 페이지 스크롤이  안되도록 막아두었습니다. 업데이트 목록만 스크롤 가능합니다.
- 수정 중일때만 toolbar가 보여집니다. (isEditing)

### 📸 Screenshot

### 📎 Reference

close #94 
