### PR TITLE
[#108] fix : ProjectModalLayout 탭 호버 색상 수정 및 themeProvider 속성 추가, 사용하지 않는 폰트 제거

### DIFF
--- a/src/components/layout/ProjectModalLayout.tsx
+++ b/src/components/layout/ProjectModalLayout.tsx
@@ -1,5 +1,4 @@
 import styled, { css } from "styled-components";
-import RobotoRegular from "../../assets/fonts/Roboto-Regular.ttf";
 
 import { ReactComponent as ProjectModalTabSVG } from "../../assets/ProjectModalTab.svg";
 
@@ -29,7 +28,10 @@ const ProjectModalTabBox = styled.div<{
   &:hover {
     cursor: pointer;
     > svg {
-      fill: ${(props) => (props.$isShow ? "#ffd43b" : "#D0D0D0")};
+      fill: ${(props) =>
+        props.$isShow
+          ? props.theme.Color.yellow1
+          : props.theme.Color.btnColor2};
     }
   }
 `;
@@ -49,13 +51,9 @@ const ProjectModalTabText = styled.span<{ $top: number; $left: number }>`
   top: ${(props) => `${props.$top}rem`};
   left: ${(props) => `${props.$left}rem`};
 
-  @font-face {
-    font-family: "RobotoRegular";
-    src: local("RobotoRegular"), url(${RobotoRegular});
-  }
-
-  font-size: 1rem;
-  font-weight: 700;
+  font-size: ${(props) => props.theme.Fs.size16};
+  font-weight: 800;
+  scale: 1.1;
 `;
 
 const ProjectModalContentBox = styled.div`

--- a/src/components/layout/ProjectModalLayout.tsx
+++ b/src/components/layout/ProjectModalLayout.tsx
@@ -19,28 +19,29 @@ const ProjectModalLayout = styled.div<{ $isShow: boolean }>`
     `};
 `;
 
-const ProjectModalTabBox = styled.div<{ $marginLeft: number }>`
+const ProjectModalTabBox = styled.div<{
+  $marginLeft: number;
+  $isShow?: boolean;
+}>`
   width: 9rem;
   position: relative;
   transform: translate(${(props) => `${props.$marginLeft}rem`}, -2rem);
   &:hover {
     cursor: pointer;
+    > svg {
+      fill: ${(props) => (props.$isShow ? "#ffd43b" : "#D0D0D0")};
+    }
   }
 `;
 
 const ProjectModalTabBackground = styled(ProjectModalTabSVG)<{
   $color: string;
-  $isShow?: boolean;
 }>`
   transition: all 0.2s ease;
 
   width: 9rem;
   height: 2rem;
   fill: ${(props) => `${props.$color}`};
-
-  &:hover {
-    fill: ${(props) => (props.$isShow ? "#ffd43b" : "#D0D0D0")};
-  }
 `;
 
 const ProjectModalTabText = styled.span<{ $top: number; $left: number }>`

--- a/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
@@ -339,7 +339,7 @@ export default function CalendarModal({
         $isShow
       >
         <ProjectModalTabBackground $color={calendarTabColor} />
-        <ProjectModalTabText $top={0.4} $left={2.5}>
+        <ProjectModalTabText $top={0.28} $left={2.5}>
           Calender
         </ProjectModalTabText>
       </ProjectModalTabBox>

--- a/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
@@ -94,6 +94,7 @@ const CalendarBox = styled.div`
   }
   // 오늘 button
   .fc-today-button {
+    transition: all 0.2s;
     opacity: 1 !important;
     background-color: #ee6a6a !important;
     width: 3rem;
@@ -101,6 +102,9 @@ const CalendarBox = styled.div`
     font-size: 0.8rem;
     color: white !important;
     border-radius: 7px;
+    &:hover {
+      background-color: #d05f5f !important;
+    }
     &:active {
       background-color: #f69c9c !important;
     }
@@ -329,8 +333,12 @@ export default function CalendarModal({
 
   return (
     <ProjectModalLayout $isShow>
-      <ProjectModalTabBox $marginLeft={2} onClick={handleCalendarTabClick}>
-        <ProjectModalTabBackground $color={calendarTabColor} $isShow />
+      <ProjectModalTabBox
+        $marginLeft={2}
+        onClick={handleCalendarTabClick}
+        $isShow
+      >
+        <ProjectModalTabBackground $color={calendarTabColor} />
         <ProjectModalTabText $top={0.4} $left={2.5}>
           Calender
         </ProjectModalTabText>

--- a/src/pages/ProjectPage/TodoModal/TodoModal.tsx
+++ b/src/pages/ProjectPage/TodoModal/TodoModal.tsx
@@ -189,8 +189,8 @@ export default function TodoModal({ todoTabColor, isTodoShow }: Props) {
 
   return (
     <ProjectModalLayout $isShow={isTodoShow}>
-      <ProjectModalTabBox $marginLeft={19.5}>
-        <ProjectModalTabBackground $color={todoTabColor} $isShow={isTodoShow} />
+      <ProjectModalTabBox $marginLeft={19.5} $isShow={isTodoShow}>
+        <ProjectModalTabBackground $color={todoTabColor} />
         <ProjectModalTabText $top={0.4} $left={3.3}>
           Todo
         </ProjectModalTabText>


### PR DESCRIPTION
### ⛳️ Task

- [x] ProjectMdoalLayout에서 기존에 사용하던 Roboto 폰트를 import 하지 않습니다.
  - 추후에 더이상 해당 폰트 파일을 사용하지 않는다면 삭제하는게 좋을 듯 합니다.
- [x] 모달 탭 텍스트 위 호버시 색상이 변경되는 버그를 해결했습니다.
- [x] themeProvider 내 값에 맞추어 ProjectModalLayout 컴포넌트를 수정했습니다. (색상 / 폰트 / 폰트사이즈)
- [x] 달력 "오늘" 버튼에 호버시 색상 변경 추가했습니다. 

### ✍️ Note

### 📸 Screenshot

### 📎 Reference

close #108 