### PR TITLE
[#116] feat : 에러페이지 공통 컴포넌트 추가

### DIFF
--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import styled from "styled-components";
+
+import { useNavigate } from "react-router-dom";
+import ConfirmBtn from "./layout/ConfirmBtnLayout";
+
+type Props = {
+  isProject403?: boolean;
+  isProject404?: boolean;
+  isKanban404?: boolean;
+  isTodo404?: boolean;
+};
+
+const ErrorLayout = styled.div`
+  position: relative;
+  height: calc(100% - 4rem);
+`;
+
+const ErrorContentBox = styled.div`
+  position: absolute;
+
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -70%);
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ErrorNumber = styled.div`
+  font-size: 4rem;
+  font-weight: 900;
+  line-height: 1.2;
+`;
+
+const ErrorInfoBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+`;
+
+const ErrorInfo = styled.div`
+  font-weight: 900;
+`;
+
+export default function ErrorPage(props: Props) {
+  const navigate = useNavigate();
+
+  const { isProject404, isProject403, isKanban404, isTodo404 } = props;
+
+  if (isProject403) {
+    return (
+      <ErrorLayout>
+        <ErrorContentBox>
+          <ErrorNumber>403</ErrorNumber>
+          <ErrorInfoBox>
+            <ErrorInfo>해당 프로젝트의 접근 권한이 없습니다.</ErrorInfo>
+            <ConfirmBtn
+              type="button"
+              $dynamicWidth="16rem"
+              onClick={() => navigate("/")}
+            >
+              Project List 페이지로 돌아가기
+            </ConfirmBtn>
+          </ErrorInfoBox>
+        </ErrorContentBox>
+      </ErrorLayout>
+    );
+  }
+
+  if (isProject404) {
+    return (
+      <ErrorLayout>
+        <ErrorContentBox>
+          <ErrorNumber>404</ErrorNumber>
+          <ErrorInfoBox>
+            <ErrorInfo>해당 프로젝트는 존재하지 않습니다.</ErrorInfo>
+            <ConfirmBtn
+              type="button"
+              $dynamicWidth="16rem"
+              onClick={() => navigate("/")}
+            >
+              Project List 페이지로 돌아가기
+            </ConfirmBtn>
+          </ErrorInfoBox>
+        </ErrorContentBox>
+      </ErrorLayout>
+    );
+  }
+
+  if (isKanban404) {
+    return (
+      <ErrorLayout>
+        <ErrorContentBox>
+          <ErrorNumber>404</ErrorNumber>
+          <ErrorInfoBox>
+            <ErrorInfo>해당 칸반은 존재하지 않습니다.</ErrorInfo>
+          </ErrorInfoBox>
+        </ErrorContentBox>
+      </ErrorLayout>
+    );
+  }
+
+  if (isTodo404) {
+    return (
+      <ErrorLayout>
+        <ErrorContentBox>
+          <ErrorNumber>404</ErrorNumber>
+          <ErrorInfoBox>
+            <ErrorInfo>해당 투두는 존재하지 않습니다.</ErrorInfo>
+          </ErrorInfoBox>
+        </ErrorContentBox>
+      </ErrorLayout>
+    );
+  }
+
+  return null;
+}
+
+ErrorPage.defaultProps = {
+  isProject403: false,
+  isProject404: false,
+  isKanban404: false,
+  isTodo404: false,
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { useLocation } from "react-router-dom";
 import { styled } from "styled-components";
 import { useRecoilValue } from "recoil";
 import userData from "../recoil/atoms/login/userDataState";
@@ -21,6 +20,7 @@ import UserProfile from "./modal/UserProfileModal";
 
 // 모달 공통 컴포넌트
 import ModalCommon from "./layout/ModalCommonLayout";
+import headerState from "../recoil/atoms/header/headerState";
 
 const HeaderLayout = styled.div`
   height: 3rem;
@@ -97,15 +97,15 @@ const modals = [
 ];
 
 export default function Header() {
-  const location = useLocation();
+  const currentHeaderState = useRecoilValue(headerState);
+
   const userDataState = useRecoilValue(userData);
   const { profile_img_URL: profileImgUrl }: any = userDataState.userData;
   const [selectedModal, setSelectedModal] = useState(-1);
-  let pageType = "list";
-  if (location.pathname !== "/") {
-    pageType = "project";
-  }
-  const listPageModals = modals.filter((modal) => modal.type === pageType);
+
+  const listPageModals = modals.filter(
+    (modal) => modal.type === currentHeaderState,
+  );
 
   const handleClick = (idx: number) => {
     setSelectedModal(idx);
@@ -115,29 +115,31 @@ export default function Header() {
     <HeaderLayout>
       <HeaderLogoParagraph>Calit!</HeaderLogoParagraph>
       <HeaderIconBox>
-        {(pageType === "list" ? listPageModals : modals).map((modal, index) => (
-          <HeaderModalBox key={modal.key} onClick={() => handleClick(index)}>
-            <ModalCommon modalSelected={selectedModal} modalIndex={index}>
-              <>
-                {modal.icon === "userProfile" ? (
-                  <img
-                    style={{
-                      width: "2rem",
-                      height: "2rem",
-                      objectFit: "cover",
-                      borderRadius: "50%",
-                    }}
-                    src={profileImgUrl}
-                    alt="modalIcon"
-                  />
-                ) : (
-                  modal.icon
-                )}
-                {modal.content}
-              </>
-            </ModalCommon>
-          </HeaderModalBox>
-        ))}
+        {(currentHeaderState === "list" ? listPageModals : modals).map(
+          (modal, index) => (
+            <HeaderModalBox key={modal.key} onClick={() => handleClick(index)}>
+              <ModalCommon modalSelected={selectedModal} modalIndex={index}>
+                <>
+                  {modal.icon === "userProfile" ? (
+                    <img
+                      style={{
+                        width: "2rem",
+                        height: "2rem",
+                        objectFit: "cover",
+                        borderRadius: "50%",
+                      }}
+                      src={profileImgUrl}
+                      alt="modalIcon"
+                    />
+                  ) : (
+                    modal.icon
+                  )}
+                  {modal.content}
+                </>
+              </ModalCommon>
+            </HeaderModalBox>
+          ),
+        )}
       </HeaderIconBox>
     </HeaderLayout>
   );

--- a/src/components/routes/ProjectCheckRoute.tsx
+++ b/src/components/routes/ProjectCheckRoute.tsx
@@ -19,6 +19,7 @@ import projectState from "../../recoil/atoms/project/projectState";
 import userState from "../../recoil/atoms/login/userDataState";
 import kanbanState from "../../recoil/atoms/kanban/kanbanState";
 import ErrorPage from "../ErrorPage";
+import headerState from "../../recoil/atoms/header/headerState";
 
 const ProjectLayout = styled.div`
   display: flex;
@@ -35,6 +36,8 @@ export default function ProjectCheckRoute() {
 
   const [is403, setIs403] = useState(false);
   const [is404, setIs404] = useState(false);
+
+  const setHeaderState = useSetRecoilState(headerState);
 
   useEffect(() => {
     // 프로젝트 문서 onSnapshot
@@ -79,6 +82,7 @@ export default function ProjectCheckRoute() {
         setProjectDataState({
           projectData: projectDoc.data(),
         });
+        setHeaderState("project");
       } else if (!projectDoc.exists()) {
         unsubProject();
         setIs404(true);
@@ -132,6 +136,7 @@ export default function ProjectCheckRoute() {
       setIs404(false);
       unsubProject();
       unsubKanban();
+      setHeaderState("list");
     };
   }, [pathname]);
 

--- a/src/recoil/atoms/header/headerState.ts
+++ b/src/recoil/atoms/header/headerState.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const headerState = atom({
+  key: "headerState",
+  default: "list",
+});
+
+export default headerState;


### PR DESCRIPTION
### ⛳️ Task

- [x] 에러페이지 컴포넌트를 추가했습니다.
  - 각 모달에서 사용할 수 있도록 prop을 여러개 받습니다.
  - 자세한 사용법은 ProjectCheckRoute에서 분기에 따른 컴포넌트 호출시 prop을 확인해 주시기 바랍니다.
  - top, left, translate 속성을 사용해 화면에 중앙으로 오도록 설정했습니다.
    - 현재 rem 높이는 헤더만 계산해서 사용하고 있어 후에 각 모달에서 쓰실때는 따로 layout을 스타일링 하셔서 사용하시면 됩니다!

### ✍️ Note

### 📸 Screenshot

### 📎 Reference

close #116 