### PR TITLE
[#137] 태그 배경 색상 변경 기능

### DIFF
--- a/src/pages/ProjectListPage/ProjectList.tsx
+++ b/src/pages/ProjectListPage/ProjectList.tsx
@@ -20,8 +20,8 @@ const ProjectListTitle = styled.div`
 const ProjectListContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(33%, auto));
-  justify-content: center;
   margin: 20px 0px;
+  justify-content: start;
 `;
 
 export default function ProjectList() {

--- a/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
@@ -234,7 +234,7 @@ const CalendarBox = styled.div`
   }
 `;
 
-const ColorModal = styled.input<{
+export const ColorModal = styled.input<{
   $isShow: boolean;
   $top: number;
   $left: number;
@@ -255,7 +255,7 @@ const ColorModal = styled.input<{
     `}
 `;
 
-const ColorModalBackground = styled.button<{ $isShow: boolean }>`
+export const ColorModalBackground = styled.button<{ $isShow: boolean }>`
   position: fixed;
 
   top: 0;

--- a/src/pages/ProjectPage/TodoModal/CustomOptions.tsx
+++ b/src/pages/ProjectPage/TodoModal/CustomOptions.tsx
@@ -1,10 +1,23 @@
-import React from "react";
+import React, { useRef, useState } from "react";
 import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
 import { useRecoilValue } from "recoil";
+import styled from "styled-components";
+import _ from "lodash";
 import TagContainer from "./TagContainer";
 import closeIcon from "../../../assets/icons/closeIcon.svg";
 import { db } from "../../../firebaseSDK";
 import singleTodoState from "../../../recoil/atoms/todo/singleTodoState";
+import {
+  ColorModal,
+  ColorModalBackground,
+} from "../CalendarModal/CalendarModal";
+import paintIcon from "../../../assets/icons/paint.svg";
+import getTextColorByBackgroundColor from "../../../utils/getTextColorByBgColor";
+
+const TodoColorModal = styled(ColorModal)`
+  position: relative;
+  z-index: 1000;
+`;
 
 export default function CustomOptions({
   innerRef,
@@ -26,6 +39,8 @@ export default function CustomOptions({
   );
   const todoDataState = useRecoilValue(singleTodoState);
   const optionData = todoDataState.todoData.todo_option_list;
+  const [isColorModalShow, setIsColorModalShow] = useState(false);
+  const [tagBgColor, setTagBgColor] = useState(color);
 
   // 옵션 삭제
   const handleOptionDelete = async (e: any) => {
@@ -41,6 +56,45 @@ export default function CustomOptions({
     });
   };
 
+  // 태그 배경 색상 변경
+  const handleOptionColor = (e: any) => {
+    e.stopPropagation();
+    setIsColorModalShow(true);
+  };
+
+  const handleTodoColorModalChange = (e: any) => {
+    setTagBgColor(e.target.value);
+  };
+  // 태그 배경 색상 변경 최적화
+  const handleTodoColorModalthrottle = useRef(
+    _.throttle((e: React.ChangeEvent<HTMLInputElement>) => {
+      handleTodoColorModalChange(e);
+    }, 100),
+  );
+  // react select 기본 선택 동작 방지
+  const handleStopPropagation = (e: any) => {
+    e.stopPropagation();
+  };
+
+  const handleModalCloseClick = async (e: any) => {
+    e.stopPropagation();
+    const updatedTodoOptionList = optionData.map((option: any) => {
+      if (option.label === label) {
+        return {
+          ...option,
+          color: tagBgColor,
+        };
+      }
+      return option;
+    });
+
+    await updateDoc(todoRef, {
+      todo_option_list: updatedTodoOptionList,
+      modified_date: serverTimestamp(),
+    });
+    setIsColorModalShow(false);
+  };
+
   return (
     <article
       ref={innerRef}
@@ -48,7 +102,34 @@ export default function CustomOptions({
       {...innerProps}
       className="custom-option"
     >
-      <TagContainer $dynamicBg={color}>{label}</TagContainer>
+      <TagContainer
+        $dynamicBg={tagBgColor}
+        $dynamicColor={getTextColorByBackgroundColor(tagBgColor)}
+      >
+        {label}
+      </TagContainer>
+      <button type="button" onClick={handleOptionColor}>
+        <img
+          src={paintIcon}
+          alt="색상"
+          style={{ width: "0.8rem", height: "0.8rem" }}
+        />
+      </button>
+      {isColorModalShow ? (
+        <TodoColorModal
+          type="color"
+          $isShow={isColorModalShow}
+          $top={0}
+          $left={0}
+          value={tagBgColor}
+          onChange={handleTodoColorModalthrottle.current}
+          onClick={handleStopPropagation}
+        />
+      ) : null}
+      <ColorModalBackground
+        $isShow={isColorModalShow}
+        onClick={handleModalCloseClick}
+      />
       {canDelete ? (
         <button type="button" onClick={handleOptionDelete}>
           <img src={closeIcon} alt="삭제" />

--- a/src/pages/ProjectPage/TodoModal/CustomOptions.tsx
+++ b/src/pages/ProjectPage/TodoModal/CustomOptions.tsx
@@ -18,6 +18,12 @@ const TodoColorModal = styled(ColorModal)`
   position: relative;
   z-index: 1000;
 `;
+// 여기는 css 수정되어야 정상 적용될 예정입니다.
+const TodoColorModalBackground = styled(ColorModalBackground)`
+  width: 100vw;
+  height: 100vh;
+  background-color: transparent;
+`;
 
 export default function CustomOptions({
   innerRef,
@@ -126,7 +132,7 @@ export default function CustomOptions({
           onClick={handleStopPropagation}
         />
       ) : null}
-      <ColorModalBackground
+      <TodoColorModalBackground
         $isShow={isColorModalShow}
         onClick={handleModalCloseClick}
       />

--- a/src/pages/ProjectPage/TodoModal/TagContainer.tsx
+++ b/src/pages/ProjectPage/TodoModal/TagContainer.tsx
@@ -2,14 +2,16 @@ import styled from "styled-components";
 
 interface Props {
   $dynamicBg: string;
+  $dynamicColor: string;
 }
 const TagContainer = styled.div<Props>`
   display: inline-block;
   background-color: ${(props) =>
-    props.$dynamicBg ? props.$dynamicBg : "#ffffff"};
+    props.$dynamicBg ? props.$dynamicBg : "#c9c9c9"};
   border-radius: 10px;
   white-space: nowrap;
   padding: 2px 10px;
+  color: ${(props) => (props.$dynamicColor ? props.$dynamicColor : "#000")};
 `;
 
 export default TagContainer;

--- a/src/pages/ProjectPage/TodoModal/TagSelectLayout.tsx
+++ b/src/pages/ProjectPage/TodoModal/TagSelectLayout.tsx
@@ -4,6 +4,7 @@ import { ActionMeta, MultiValue } from "react-select";
 import { serverTimestamp, updateDoc } from "firebase/firestore";
 import CustomOptions from "./CustomOptions";
 import TagContainer from "./TagContainer";
+import getTextColorByBackgroundColor from "../../../utils/getTextColorByBgColor";
 
 export default function TagSelectLayout({ todoRef, todoDataState }: any) {
   const optionData = todoDataState.todoData.todo_option_list;
@@ -52,7 +53,12 @@ export default function TagSelectLayout({ todoRef, todoDataState }: any) {
       options={optionData}
       // eslint-disable-next-line react/no-unstable-nested-components
       formatOptionLabel={(option: any) => (
-        <TagContainer $dynamicBg={option.color}>{option.label}</TagContainer>
+        <TagContainer
+          $dynamicBg={option.color}
+          $dynamicColor={getTextColorByBackgroundColor(option.color)}
+        >
+          {option.label}
+        </TagContainer>
       )}
       value={todoDataState.todoData.todo_tag_list}
       getNewOptionData={getNewOptionData}


### PR DESCRIPTION
### ⛳️ Task

- [x] 태그 배경 색상 변경 기능
- [x] project list 페이지 카드 grid 정렬 수정 (개수가 적으면 중앙정렬 되어보이는 문제 해결) 

### ✍️ Note
 **태그 배경 색상 변경 기능 추가**
- 기존 캘린더 모달에서 사용했던 color picker 기능 응용
- lodash throttle을 활용한 최적화

약간의 이슈..(?)
- 캘린더 모달에선 onBlur 이벤트가 잘 작동하는데 react - select에서는 onBlur를 못하는 문제가 있었음.
- 그래서 color picker 모달 뒤쪽으로 깔리는 ColorModalBackground 컴포넌트를 클릭 시 update되는 형식으로 만듦. -> 캘린더 모달에서와 동작이 유사해보이긴함. 하지만 헤더/사이드바 쪽 클릭했을 땐 취소가 되는 듯해 보이는 문제 존재..,.,.,.,
ㄴ 해결 방법 제안
  - ColorModalBackground를 전체화면으로 덮어버리기. (하지만 전체화면을 덮지 못하는 이슈 발생)
ㄴ 원인 발견 !!
    - ProjectModalLayout.tsx에 있는 ProjectModalContentBox의   transform: translateY(-2rem);
    - todo모달 페이지에서는 overflow: hidden 도 없애줘야 함.

### 📸 Screenshot

### 📎 Reference
