### PR TITLE
[#132] feat : kanbanModal 개선 및 기타 변경 사항

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "firebase": "^10.4.0",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
-        "react-beautiful-dnd": "^13.1.1",
         "react-datepicker": "^4.21.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.16.0",
@@ -36,10 +35,12 @@
         "recoil-persist": "^5.1.0",
         "styled-components": "^6.0.8",
         "typescript": "^4.9.5",
+        "uuid": "^9.0.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.200",
+        "@types/uuid": "^9.0.6",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "eslint": "^8.51.0",
@@ -5219,17 +5220,6 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/react-redux": {
-      "version": "7.1.27",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.27.tgz",
-      "integrity": "sha512-xj7d9z32p1K/eBmO+OEy+qfaWXtcPlN8f1Xk3Ne0p/ZRQ867RI5bQ/bpBtxbqU1AHNhKJSgGvld/P2myU2uYkg==",
-      "dependencies": {
-        "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0",
-        "redux": "^4.0.0"
-      }
-    },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.8",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.8.tgz",
@@ -5328,6 +5318,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
       "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
+      "integrity": "sha512-BT2Krtx4xaO6iwzwMFUYvWBWkV2pr37zD68Vmp1CDV196MzczBRxuEpD6Pr395HAgebC/co7hOphs53r8V7jew==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.6",
@@ -13994,11 +13990,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
-    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -16984,24 +16975,6 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
-    "node_modules/react-beautiful-dnd": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
-      "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2",
-        "css-box-model": "^1.2.0",
-        "memoize-one": "^5.1.1",
-        "raf-schd": "^4.0.2",
-        "react-redux": "^7.2.0",
-        "redux": "^4.0.4",
-        "use-memo-one": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-datepicker": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.21.0.tgz",
@@ -17223,30 +17196,6 @@
         "@popperjs/core": "^2.0.0",
         "react": "^16.8.0 || ^17 || ^18",
         "react-dom": "^16.8.0 || ^17 || ^18"
-      }
-    },
-    "node_modules/react-redux": {
-      "version": "7.2.9",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
-      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
-        "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-refresh": {
@@ -18480,6 +18429,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      }
+    },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/source-list-map": {
@@ -19981,9 +19938,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "firebase": "^10.4.0",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
-    "react-beautiful-dnd": "^13.1.1",
     "react-datepicker": "^4.21.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0",
@@ -31,6 +30,7 @@
     "recoil-persist": "^5.1.0",
     "styled-components": "^6.0.8",
     "typescript": "^4.9.5",
+    "uuid": "^9.0.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.200",
+    "@types/uuid": "^9.0.6",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "eslint": "^8.51.0",

--- a/src/api/CreateCollection.tsx
+++ b/src/api/CreateCollection.tsx
@@ -16,11 +16,9 @@ interface TodoData {
   update_list: Array<Object>;
   user_list: Array<string>;
   name: string;
-  order: number;
   created_date: FieldValue;
   modified_date: FieldValue;
   is_deleted: boolean;
-  stageID: string;
   deadline: Date;
   info: string;
   todo_tag_list: Array<Object>;
@@ -44,10 +42,12 @@ export const createTodo = async (
   documentId: string,
   kanbanId: string,
   data: TodoData,
-): Promise<void> => {
-  await addDoc(
+): Promise<string> => {
+  const docRef = await addDoc(
     collection(db, "project", documentId, "kanban", kanbanId, "todo"),
     data,
   );
   // alert("투두를 생성했습니다");
+  const newTodoId = docRef.id;
+  return newTodoId;
 };

--- a/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useEffect, useRef, useState } from "react";
 import {
   DateSelectArg,
@@ -522,7 +521,6 @@ export default function CalendarModal({
         type="color"
         value={colorModalInfo.color}
         onChange={handleColorModalthrottle.current}
-        // onChange={handleColorModalChange}
         onBlur={handleColorModalBlur}
       />
       <ColorModalBackground

--- a/src/pages/ProjectPage/CalendarModal/CreateKanbanModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CreateKanbanModal.tsx
@@ -126,22 +126,19 @@ export default function CreateKanbanModal(props: Props) {
     }
     const DEFAULT_STAGES = [
       {
-        name: "완료",
-        order: 0,
-        created_date: new Date(),
-        modified_date: new Date(),
-      },
-      {
+        id: "default-1",
         name: "작업 중",
-        order: 1,
-        created_date: new Date(),
-        modified_date: new Date(),
+        todoIds: [],
       },
       {
+        id: "default-2",
         name: "작업 전",
-        order: 2,
-        created_date: new Date(),
-        modified_date: new Date(),
+        todoIds: [],
+      },
+      {
+        id: "default-3",
+        name: "완료",
+        todoIds: [],
       },
     ];
     const kanbanID = await createKanban(location.pathname, {
@@ -159,11 +156,9 @@ export default function CreateKanbanModal(props: Props) {
       update_list: [],
       user_list: [],
       name: "dummyTodo",
-      order: -1,
       created_date: serverTimestamp(),
       modified_date: serverTimestamp(),
       is_deleted: true,
-      stageID: "dummyTodo",
       deadline: new Date(),
       info: "dummy",
       todo_tag_list: [],

--- a/src/pages/ProjectPage/KanbanModal/KanbanStageBox.tsx
+++ b/src/pages/ProjectPage/KanbanModal/KanbanStageBox.tsx
@@ -1,0 +1,326 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable react/jsx-props-no-spreading */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React, { useCallback, useEffect, useState } from "react";
+import { styled } from "styled-components";
+import { doc, getDoc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { DragDropContext, DropResult, Droppable } from "@hello-pangea/dnd";
+import { useRecoilValue } from "recoil";
+import { v4 as uuid } from "uuid";
+
+import { createTodo } from "../../../api/CreateCollection";
+import todoDataState from "../../../recoil/atoms/todo/todoState";
+import icon_plus_circle from "../../../assets/icons/icon_plus_circle.svg";
+import trashIcon from "../../../assets/icons/trashIcon.svg";
+import { db } from "../../../firebaseSDK";
+import Column from "./Stage";
+
+const StageLayout = styled.div`
+  display: flex;
+`;
+
+const StageBox = styled.div`
+  height: 20rem;
+  width: 10rem;
+  margin: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const StageInfoBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 10rem;
+  border-bottom: 2px solid #eaeaea;
+  margin-bottom: 0.5rem;
+`;
+const StageContentBox = styled.div`
+  box-sizing: border-box;
+
+  height: 60vh;
+  width: 10vw;
+  padding: 0 0.5rem;
+
+  background: #ededed;
+  border: 1px solid #d5d5d5;
+  box-shadow: 3px 4px 9px -2px rgba(0, 0, 0, 0.13);
+  border-radius: 10px;
+  overflow: scroll;
+`;
+
+const StageContent = styled.div`
+  height: 4rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+
+  border-radius: 10px;
+  border: 1px solid #d5d5d5;
+  background: #fff;
+`;
+
+const StageContentParagraph = styled.p`
+  &.title {
+    font-weight: bold;
+  }
+`;
+
+const StageIconBox = styled.div`
+  display: flex;
+`;
+
+const StageInfoTrashIcon = styled.img`
+  height: 1rem;
+  width: 1rem;
+  cursor: pointer;
+  display: none;
+`;
+
+const StageInfoPlusIcon = styled.img`
+  height: 1rem;
+  width: 1rem;
+  cursor: pointer;
+`;
+
+const Container = styled.div`
+  display: flex;
+`;
+
+interface Props {
+  stageList: any;
+  isKanbanShow: boolean;
+}
+
+interface IData {
+  tasks: {
+    [key: string]: { id: string; content: string };
+  };
+  columns: {
+    [key: string]: { id: string; title: string; taskIds: string[] };
+  };
+  columnOrder: string[];
+}
+
+export interface InitialData {
+  todos: {
+    [key: string]: { id: string; name: string };
+  };
+  stages: {
+    [key: string]: { id: string; name: string; todoIds: string[] };
+  };
+  stageOrder: string[];
+}
+
+export default function KanbanStageBox({ stageList, isKanbanShow }: Props) {
+  const urlQueryString = new URLSearchParams(window.location.search);
+  const projectID = window.location.pathname.substring(1);
+  const kanbanID = String(urlQueryString.get("kanbanID"));
+  const kanbanRef = doc(db, "project", projectID, "kanban", kanbanID);
+
+  const todoState = useRecoilValue(todoDataState);
+
+  const initialData: InitialData = {
+    todos: {},
+    stages: {},
+    stageOrder: [],
+  };
+
+  const [data, setData] = useState<InitialData>(initialData);
+
+  useEffect(() => {
+    if (!isKanbanShow) return;
+    const updatedData: InitialData = {
+      todos: {},
+      stages: {},
+      stageOrder: [],
+    };
+
+    // 1-1. stageList 배열 반복문
+    stageList.forEach((stage: any) => {
+      updatedData.stages[stage.id] = stage;
+      updatedData.stageOrder.push(stage.id);
+    });
+
+    // 1-2. todoState Map 반복문
+    todoState.forEach((value, key) => {
+      value.id = key;
+      updatedData.todos[key] = value;
+    });
+
+    setData(updatedData);
+  }, [todoState, stageList, isKanbanShow]);
+
+  // 변경시 업데이트 해야할 것
+  // 1. stageList 배열 순서
+  // 2. stage 내 todoIds 순서
+  const handleOnDragEnd = useCallback(
+    (result: DropResult) => {
+      const { destination, source, draggableId, type } = result;
+      if (!destination) return;
+      if (
+        destination.droppableId === source.droppableId &&
+        source.index === destination.index
+      )
+        return;
+
+      if (type === "column") {
+        const newColumnOrder = Array.from(data.stageOrder);
+        newColumnOrder.splice(source.index, 1);
+        newColumnOrder.splice(destination.index, 0, draggableId);
+
+        const newData = {
+          ...data,
+          stageOrder: newColumnOrder,
+        };
+        setData(newData);
+        return;
+      }
+      const startColumn = data.stages[source.droppableId];
+      const finishColumn = data.stages[destination.droppableId];
+
+      if (startColumn === finishColumn) {
+        const newTaskIds = Array.from(startColumn.todoIds);
+        newTaskIds.splice(source.index, 1);
+        newTaskIds.splice(destination.index, 0, draggableId);
+
+        const newColumn = {
+          ...startColumn,
+          todoIds: newTaskIds,
+        };
+
+        const newData = {
+          ...data,
+          stages: {
+            ...data.stages,
+            [newColumn.id]: newColumn,
+          },
+        };
+
+        setData(newData);
+      } else {
+        const startTaskIds = Array.from(startColumn.todoIds);
+        startTaskIds.splice(source.index, 1);
+        const newStartColumn = {
+          ...startColumn,
+          todoIds: startTaskIds,
+        };
+
+        const finishTaskIds = Array.from(finishColumn.todoIds);
+        finishTaskIds.splice(destination.index, 0, draggableId);
+        const newFinishColumn = {
+          ...finishColumn,
+          todoIds: finishTaskIds,
+        };
+
+        const newData = {
+          ...data,
+          stages: {
+            ...data.stages,
+            [newStartColumn.id]: newStartColumn,
+            [newFinishColumn.id]: newFinishColumn,
+          },
+        };
+
+        setData(newData);
+      }
+    },
+    [data],
+  );
+
+  const handleAddTodoClick = async (stageId: string) => {
+    const todoId = await createTodo(projectID, kanbanID, {
+      update_list: [],
+      user_list: [],
+      name: "테스트투두",
+      created_date: serverTimestamp(),
+      modified_date: serverTimestamp(),
+      is_deleted: false,
+      deadline: new Date(),
+      info: "내용",
+      todo_tag_list: [],
+      todo_option_list: [
+        {
+          label: "긴급🔥",
+          value: "긴급🔥",
+          color: "#f92f66",
+          canDelete: false,
+        },
+        { label: "FE✨", value: "FE✨", color: "#ddafff", canDelete: false },
+        { label: "BE🛠️", value: "BE🛠️", color: "#F5F3BB", canDelete: false },
+        {
+          label: "UX/UI🎨",
+          value: "UX/UI🎨",
+          color: "#00FFF5",
+          canDelete: false,
+        },
+      ],
+    });
+    const updatedStageList = stageList.map((stage: any) => {
+      if (stage.id === stageId) {
+        stage.todoIds.push(todoId);
+        return stage;
+      }
+      return stage;
+    });
+    await updateDoc(kanbanRef, {
+      stage_list: updatedStageList,
+    });
+  };
+
+  const handleAddStageClick = async () => {
+    stageList.push({
+      id: uuid(),
+      name: `새 스테이지`,
+      todoIds: [],
+    });
+    await updateDoc(kanbanRef, {
+      stage_list: stageList,
+    });
+  };
+
+  return (
+    <StageLayout>
+      <DragDropContext onDragEnd={handleOnDragEnd}>
+        <Droppable
+          droppableId="all-columns"
+          direction="horizontal"
+          type="column"
+          getContainerForClone={() => document.body}
+        >
+          {(provided) => (
+            <Container {...provided.droppableProps} ref={provided.innerRef}>
+              {data.stageOrder.map((columnId, index) => {
+                const stage = data.stages[columnId];
+                const todos = stage.todoIds.map((todoId) => data.todos[todoId]);
+                return (
+                  <Column
+                    stage={stage}
+                    todos={todos}
+                    key={stage.id}
+                    index={index}
+                    handleAddTodoClick={handleAddTodoClick}
+                  />
+                );
+              })}
+              {provided.placeholder}
+            </Container>
+          )}
+        </Droppable>
+      </DragDropContext>
+      <StageBox>
+        <StageInfoBox>
+          스테이지 추가하기
+          <StageInfoTrashIcon src={trashIcon} alt="스테이지 삭제" />
+          <StageInfoPlusIcon
+            src={icon_plus_circle}
+            alt="스테이지 추가"
+            onClick={handleAddStageClick}
+          />
+        </StageInfoBox>
+        <StageContentBox />
+      </StageBox>
+    </StageLayout>
+  );
+}

--- a/src/pages/ProjectPage/KanbanModal/Stage.tsx
+++ b/src/pages/ProjectPage/KanbanModal/Stage.tsx
@@ -1,411 +1,98 @@
-import React, { useEffect, useState } from "react";
-import { styled } from "styled-components";
-// import { useSearchParams } from "react-router-dom";
-import {
-  collection,
-  doc,
-  getDoc,
-  onSnapshot,
-  query,
-  serverTimestamp,
-  updateDoc,
-  where,
-} from "firebase/firestore";
-import {
-  DragDropContext,
-  Draggable,
-  Droppable,
-  DropResult,
-} from "@hello-pangea/dnd";
-import { useRecoilState, useSetRecoilState } from "recoil";
-import { createTodo } from "../../../api/CreateCollection";
-import todoState from "../../../recoil/atoms/todo/todoState";
-import kanbanState from "../../../recoil/atoms/kanban/kanbanState";
+/* eslint-disable no-param-reassign */
+/* eslint-disable @typescript-eslint/no-shadow */
+/* eslint-disable react/jsx-props-no-spreading */
+/* eslint-disable react/react-in-jsx-scope */
+import styled from "styled-components";
+import { Droppable, Draggable } from "@hello-pangea/dnd";
+
 import icon_plus_circle from "../../../assets/icons/icon_plus_circle.svg";
-import trashIcon from "../../../assets/icons/trashIcon.svg";
-import { db } from "../../../firebaseSDK";
+import Task from "./Todo";
 
-const StageLayout = styled.div`
-  display: flex;
-  overflow: scroll;
-  height: 70vh;
-`;
+const Container = styled.div`
+  margin: 8px;
+  border: 1px solid lightgrey;
+  border-radius: 2px;
+  width: 220px;
 
-const StageBox = styled.div`
-  height: 20rem;
-  width: 10rem;
-  margin: 0.5rem;
   display: flex;
   flex-direction: column;
-  align-items: center;
+`;
+const Title = styled.h3`
+  padding: 8px;
 `;
 
-const StageInfoBox = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 10rem;
-  border-bottom: 2px solid #eaeaea;
-  margin-bottom: 0.5rem;
-`;
-const StageContentBox = styled.div`
-  box-sizing: border-box;
-
-  height: 60vh;
-  width: 10vw;
-  padding: 0 0.5rem;
-
-  background: #ededed;
-  border: 1px solid #d5d5d5;
-  box-shadow: 3px 4px 9px -2px rgba(0, 0, 0, 0.13);
-  border-radius: 10px;
-  overflow: scroll;
-`;
-
-const StageContent = styled.div`
-  height: 4rem;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-
-  border-radius: 10px;
-  border: 1px solid #d5d5d5;
-  background: #fff;
-`;
-
-const StageContentParagraph = styled.p`
-  &.title {
-    font-weight: bold;
-  }
-`;
-
-const StageIconBox = styled.div`
-  display: flex;
-`;
-
-const StageInfoTrashIcon = styled.img`
-  height: 1rem;
-  width: 1rem;
-  cursor: pointer;
-  display: none;
-`;
-
-const StageInfoPlusIcon = styled.img`
+const TodoPlusIcon = styled.img`
   height: 1rem;
   width: 1rem;
   cursor: pointer;
 `;
 
-interface Props {
-  stageLists: any; // 삭제예정
-  isKanbanShow: boolean;
+interface ITaskList {
+  $isDraggingOver: boolean;
+}
+const TaskList = styled.div<ITaskList>`
+  padding: 8px;
+  background-color: ${(props) => (props.$isDraggingOver ? "skyblue" : "white")};
+  flex-grow: 1;
+`;
+
+interface IColumnProps {
+  stage: { id: string; name: string; todoIds: string[] };
+  todos: {
+    id: string;
+    name: string;
+  }[];
+  index: number;
+  handleAddTodoClick: any;
 }
 
-export default function Stage({ stageLists, isKanbanShow }: Props) {
-  // const [searchParams, setSearchParams] = useSearchParams();
-  const [todoLists, setTodoLists] = useState([]);
-  const urlQueryString = new URLSearchParams(window.location.search);
-  const projectID = window.location.pathname.substring(1);
-  const kanbanID = isKanbanShow
-    ? String(urlQueryString.get("kanbanID"))
-    : "null";
-  const [todoDataState, setTodoDataState] = useRecoilState(todoState);
-  const [isStage, setIsStage] = useState(stageLists); // 삭제 예정
-  const setKanbanDataState = useSetRecoilState(kanbanState);
-
-  // const [todoData, setTodoData] = useState(todoDataState);
-  const addedMap = todoDataState?.todoData?.size
-    ? todoDataState.todoData
-    : new Map();
-  const todoData1 = { todoData: addedMap };
-
-  useEffect(() => {
-    if (!isKanbanShow) {
-      return;
-    }
-
-    const todoQuery = query(
-      collection(db, "project", projectID, "kanban", kanbanID, "todo"),
-      where("is_deleted", "==", false),
-    );
-
-    const unsubTodo = onSnapshot(todoQuery, (todoSnapshot) => {
-      const todos: any = [];
-      todoSnapshot.docChanges().forEach((change) => {
-        if (change.type === "added") {
-          addedMap.set(change.doc.id, change.doc.data());
-        }
-
-        if (change.type === "modified") {
-          addedMap.set(change.doc.id, change.doc.data());
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          setTodoDataState((todoData: any | Map<any, any>) => {
-            addedMap.set(change.doc.id, change.doc.data());
-            return todoData1;
-          });
-        }
-        if (change.type === "removed") {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          setTodoDataState((todoData: any | Map<any, any>) => {
-            addedMap.delete(change.doc.id);
-            return todoData1;
-          });
-        }
-
-        // if (addedMap.size > 0) {
-        //     // setTodoDataState((todoData) => new Map([...prev, ...addedMap]));
-        //     setTodoDataState(todoData1);
-        //   }
-
-        setTodoDataState(todoData1);
-      });
-      addedMap.forEach((value: any) => {
-        todos.push(value);
-        // if (!todos[value.stageID]) {
-        //   todos[value.stageID] = [value];
-        // } else {
-        //   todos[value.stageID].push(value);
-        // }
-      });
-
-      if (addedMap) {
-        // const todos: any = [];
-        // stageLists.forEach((singleStage: any) => {
-        //   todos[singleStage.name] = [];
-        // });
-
-        // console.log(todos);
-        // addedMap.forEach((ad: any) => {
-        //   console.log(todos);
-        //   todos[ad.stageID].push(ad);
-        // });
-
-        // console.log(todos);
-        setTodoLists(todos);
-      }
-      return () => {
-        unsubTodo();
-      };
-    });
-  }, [kanbanID]);
-
-  const handleTodoAddClick = async (stageOrder: number, stageName: string) => {
-    await createTodo(projectID, kanbanID, {
-      update_list: [],
-      user_list: [],
-      name: "테스트투두",
-      order: stageOrder,
-      created_date: serverTimestamp(),
-      modified_date: serverTimestamp(),
-      is_deleted: false,
-      stageID: stageName,
-      deadline: new Date(),
-      info: "내용",
-      todo_tag_list: [],
-      todo_option_list: [
-        {
-          label: "긴급🔥",
-          value: "긴급🔥",
-          color: "#f92f66",
-          canDelete: false,
-        },
-        { label: "FE✨", value: "FE✨", color: "#ddafff", canDelete: false },
-        { label: "BE🛠️", value: "BE🛠️", color: "#F5F3BB", canDelete: false },
-        {
-          label: "UX/UI🎨",
-          value: "UX/UI🎨",
-          color: "#00FFF5",
-          canDelete: false,
-        },
-      ],
-    });
-    // console.log("todo created");
-  };
-
-  const handleAddStageClick = async () => {
-    const kanbanRef = doc(db, "project", projectID, "kanban", kanbanID);
-    const newStage = isStage
-      .concat({
-        name: `새 스테이지 ${isStage.length - 2}`,
-        order: isStage.length,
-        created_date: new Date(),
-        modified_date: new Date(),
-      })
-      .sort((a: any, b: any) => b.order - a.order);
-    await updateDoc(kanbanRef, {
-      stage_list: newStage,
-    });
-    setIsStage(newStage);
-
-    const targetDoc = await getDoc(kanbanRef);
-    setKanbanDataState((prev) => {
-      prev.set(targetDoc.id, targetDoc.data());
-      return new Map([...prev]);
-    });
-  };
-
-  const getStageListStyle = (isDraggingOver: any) => ({
-    background: isDraggingOver ? "lightblue" : "lightgrey",
-    display: "flex",
-    padding: "8px",
-    margin: "12px",
-    overflow: "auto",
-  });
-
-  const onDragEnd = async (result: DropResult) => {
-    // drop이 불가능한 공간으로 드래그한 경우
-    if (!result.destination) return;
-
-    // 출발지와 목적지가 같은 경우
-    if (
-      result.destination.droppableId === result.source.droppableId &&
-      result.destination.index === result.source.index
-    )
-      return;
-
-    if (result.destination) {
-      const beforeDragIndex = result.source.index;
-      const beforeDragDroppableId = result.source.droppableId;
-      const afterDragIndex = result.destination.index;
-      const afterDragDroppableId = result.destination.droppableId;
-
-      // 스테이지의 배열 이동
-      if (
-        beforeDragDroppableId.indexOf("inner") === -1 ||
-        afterDragDroppableId.indexOf("inner") === -1
-      ) {
-        const [selectedStage] = isStage.splice(beforeDragIndex, 1);
-        isStage.splice(afterDragIndex, 0, selectedStage);
-        setIsStage(isStage);
-        const kanbanRef = doc(db, "project", projectID, "kanban", kanbanID);
-        await updateDoc(kanbanRef, {
-          stage_list: isStage,
-        });
-        const targetDoc = await getDoc(kanbanRef);
-        setKanbanDataState((prev) => {
-          prev.set(targetDoc.id, targetDoc.data());
-          return new Map([...prev]);
-        });
-      } else {
-        // 투두의 배열 이동
-        // console.log("before", todoLists);
-      }
-    }
-  };
+function Stage({ stage, todos, index, handleAddTodoClick }: IColumnProps) {
   return (
-    <StageLayout>
-      <DragDropContext onDragEnd={onDragEnd}>
-        <Droppable
-          droppableId="stageDroppable"
-          key="stageDroppable"
-          direction="horizontal"
-        >
-          {/* eslint-disable-next-line @typescript-eslint/no-unused-vars */}
-          {(provided, snapshot) => (
-            <div
-              ref={provided.innerRef}
-              style={getStageListStyle(snapshot.isDraggingOver)}
-              // eslint-disable-next-line react/jsx-props-no-spreading
-              {...provided.droppableProps}
-            >
-              {isStage.map((stage: any, index: number) => (
-                <Draggable
-                  draggableId={stage.order.toString()}
-                  index={index}
-                  key={stage.order.toString()}
-                >
-                  {(draggableProvided) => (
-                    <div
-                      ref={draggableProvided.innerRef}
-                      // eslint-disable-next-line react/jsx-props-no-spreading
-                      {...draggableProvided.dragHandleProps}
-                      // eslint-disable-next-line react/jsx-props-no-spreading
-                      {...draggableProvided.draggableProps}
-                    >
-                      <StageBox key={stage.name}>
-                        <StageInfoBox>
-                          {stage.name}
-                          <StageIconBox>
-                            <StageInfoTrashIcon
-                              src={trashIcon}
-                              alt="스테이지 삭제"
-                            />
-                            <StageInfoPlusIcon
-                              src={icon_plus_circle}
-                              alt="투두 추가"
-                              onClick={() =>
-                                handleTodoAddClick(stage.order, stage.name)
-                              }
-                            />
-                          </StageIconBox>
-                        </StageInfoBox>
-                        <Droppable
-                          droppableId={`inner-${stage.name}`}
-                          key={`inner-${stage.name}`}
-                          type="sub"
-                        >
-                          {(innerProvided) => (
-                            <div
-                              ref={innerProvided.innerRef}
-                              // eslint-disable-next-line react/jsx-props-no-spreading
-                              {...innerProvided.droppableProps}
-                            >
-                              <StageContentBox>
-                                {todoLists
-                                  ?.filter(
-                                    (stageTodo: any) =>
-                                      stageTodo.stageID === stage.name,
-                                  )
-                                  .map((todo: any, innerIndex: number) => (
-                                    <Draggable
-                                      draggableId={`${todo.stageID}-${todo.created_date.seconds}`}
-                                      index={innerIndex}
-                                      key={`${todo.stageID}-${todo.created_date.seconds}`}
-                                    >
-                                      {(innerDraggableProvided) => (
-                                        <div
-                                          ref={innerDraggableProvided.innerRef}
-                                          // eslint-disable-next-line react/jsx-props-no-spreading
-                                          {...innerDraggableProvided.dragHandleProps}
-                                          // eslint-disable-next-line react/jsx-props-no-spreading
-                                          {...innerDraggableProvided.draggableProps}
-                                        >
-                                          <StageContent>
-                                            <StageContentParagraph>
-                                              {todo.name}
-                                            </StageContentParagraph>
-                                          </StageContent>
-                                        </div>
-                                      )}
-                                    </Draggable>
-                                  ))}
-                              </StageContentBox>
-                              {innerProvided.placeholder}
-                            </div>
-                          )}
-                        </Droppable>
-                      </StageBox>
-                    </div>
-                  )}
-                </Draggable>
-              ))}
-              {provided.placeholder}
+    <Draggable draggableId={stage.id} index={index}>
+      {(provided, snapshot) => {
+        // Todo : 드래그 시 요소가 정확한 위치에 오도록 하는 해결법을 찾지 못해 삽질하다가 임시방편으로 해결. 추후 확인할 것.
+        // 이 문제는 ProjectModalLayout의 transform translate 속성을 제거할 경우 해결 됨.
+        // 참고 깃헙 주소: https://github.com/atlassian/react-beautiful-dnd/issues/1881
+        const viewportNode = document.getElementById("kanbanModalContentBox");
+        if (snapshot.isDragging) {
+          // @ts-ignore
+          provided.draggableProps.style.left -= viewportNode.offsetLeft + 206;
+          // @ts-ignore
+          provided.draggableProps.style.top = "auto !important";
+        }
+
+        return (
+          <Container ref={provided.innerRef} {...provided.draggableProps}>
+            <div style={{ display: "flex", alignItems: "center" }}>
+              <Title {...provided.dragHandleProps}>{stage.name}</Title>
+              <TodoPlusIcon
+                src={icon_plus_circle}
+                alt="스테이지 추가"
+                onClick={() => handleAddTodoClick(stage.id)}
+              />
             </div>
-          )}
-        </Droppable>
-      </DragDropContext>
-      <StageBox>
-        <StageInfoBox>
-          스테이지 추가하기
-          <StageInfoTrashIcon src={trashIcon} alt="스테이지 삭제" />
-          <StageInfoPlusIcon
-            src={icon_plus_circle}
-            alt="스테이지 추가"
-            onClick={() => handleAddStageClick()}
-          />
-        </StageInfoBox>
-        <StageContentBox />
-      </StageBox>
-    </StageLayout>
+
+            <Droppable droppableId={stage.id} type="task">
+              {(provided, snapshot) => (
+                <TaskList
+                  {...provided.droppableProps}
+                  ref={provided.innerRef}
+                  $isDraggingOver={snapshot.isDraggingOver}
+                >
+                  <>
+                    {todos.map((todo, idx) => (
+                      <Task key={todo.id} todo={todo} index={idx} />
+                    ))}
+                    {provided.placeholder}
+                  </>
+                </TaskList>
+              )}
+            </Droppable>
+          </Container>
+        );
+      }}
+    </Draggable>
   );
 }
+
+export default Stage;

--- a/src/pages/ProjectPage/KanbanModal/Todo.tsx
+++ b/src/pages/ProjectPage/KanbanModal/Todo.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import styled from "styled-components";
+import React from "react";
+import { Draggable } from "@hello-pangea/dnd";
+import { useSearchParams } from "react-router-dom";
+
+interface IContainer {
+  $isDragging: boolean;
+}
+
+const Container = styled.div<IContainer>`
+  border: 1px solid lightgrey;
+  border-radius: 2px;
+  padding: 8px;
+  margin-bottom: 8px;
+  transition: background-color 0.2s ease;
+  background-color: ${(props) => (props.$isDragging ? "lightgreen" : "white")};
+`;
+
+interface ITaskProps {
+  todo: {
+    id: string;
+    name: string;
+  };
+  index: number;
+}
+
+function Todo({ todo, index }: ITaskProps) {
+  const [, setSearchParams] = useSearchParams();
+  const urlQueryString = new URLSearchParams(window.location.search);
+  const kanbanID = String(urlQueryString.get("kanbanID"));
+
+  const handleTodoClick = () => {
+    setSearchParams({
+      kanbanID,
+      todoID: todo.id,
+    });
+  };
+
+  return (
+    <Draggable draggableId={todo.id} index={index}>
+      {(provided, snapshot) => (
+        <Container
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          ref={provided.innerRef}
+          $isDragging={snapshot.isDragging}
+          style={{
+            ...provided.draggableProps.style,
+            left: "auto !important",
+            top: "auto !important",
+          }}
+          onClick={handleTodoClick}
+        >
+          {todo.name}
+        </Container>
+      )}
+    </Draggable>
+  );
+}
+
+export default React.memo(Todo);

--- a/src/pages/ProjectPage/Project.tsx
+++ b/src/pages/ProjectPage/Project.tsx
@@ -1,10 +1,14 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useSearchParams } from "react-router-dom";
 
+import { collection, onSnapshot, query, where } from "firebase/firestore";
+import { useSetRecoilState } from "recoil";
 import CalendarModal from "./CalendarModal/CalendarModal";
 import KanbanModal from "./KanbanModal/KanbanModal";
 import TodoModal from "./TodoModal/TodoModal";
+import { db } from "../../firebaseSDK";
+import todoState from "../../recoil/atoms/todo/todoState";
 
 const ProjectLayout = styled.div`
   position: relative;
@@ -30,24 +34,82 @@ const ProjectLayoutFooter = styled.div`
 
 export default function Project() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const setTestTodoDataState = useSetRecoilState(todoState);
+
+  const [isKanbanShow, setIsKanbanShow] = useState(false);
+  const [isTodoShow, setIsTodoShow] = useState(false);
 
   let calendarTabColor = "#FFD43B";
   let kanbanTabColor = "#ffea7a";
   let todoTabColor = "#ffea7a";
 
-  let iskanbanShow = false;
-  let isTodoShow = false;
-
   if (searchParams.has("kanbanID")) {
     calendarTabColor = "#ffea7a";
     kanbanTabColor = "#FFD43B";
-    iskanbanShow = true;
+    if (searchParams.has("todoID")) {
+      todoTabColor = "#FFD43B";
+      kanbanTabColor = "#ffea7a";
+    }
   }
-  if (searchParams.has("todoID")) {
-    kanbanTabColor = "#ffea7a";
-    todoTabColor = "#FFD43B";
-    isTodoShow = true;
-  }
+
+  useEffect(() => {
+    if (!searchParams.has("kanbanID")) {
+      return;
+    }
+    setTestTodoDataState(new Map());
+    const projectID = window.location.pathname.substring(1);
+    const kanbanID = searchParams.get("kanbanID");
+    const todoQuery = query(
+      collection(db, "project", projectID, "kanban", kanbanID!, "todo"),
+      where("is_deleted", "==", false),
+    );
+
+    const unsubTodo = onSnapshot(todoQuery, (todoSnapshot) => {
+      const addedMap = new Map();
+      todoSnapshot.docChanges().forEach((change) => {
+        // 최초 Snapshot 생성 혹은 사용자가 직접 투두를 추가했을 때
+        if (change.type === "added") {
+          addedMap.set(change.doc.id, change.doc.data());
+        }
+        // 투두를 수정할 경우
+        if (change.type === "modified") {
+          setTestTodoDataState((prev) => {
+            prev.set(change.doc.id, change.doc.data());
+            return new Map([...prev]);
+          });
+        }
+        // 투두가 삭제된 경우 (is_deleted 수정 시 쿼리 결과 변경)
+        if (change.type === "removed") {
+          setTestTodoDataState((prev) => {
+            prev.delete(change.doc.id);
+            return new Map([...prev]);
+          });
+        }
+      });
+      if (addedMap.size > 0) {
+        setTestTodoDataState((prev) => new Map([...prev, ...addedMap]));
+      }
+      setIsKanbanShow(true);
+      if (searchParams.has("todoID")) {
+        setIsTodoShow(true);
+      }
+    });
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      setIsKanbanShow(false);
+      unsubTodo();
+    };
+  }, [searchParams.get("kanbanID")]);
+
+  useEffect(() => {
+    if (isKanbanShow && searchParams.has("todoID")) {
+      setIsTodoShow(true);
+    }
+    return () => {
+      setIsTodoShow(false);
+    };
+  }, [searchParams.get("todoID"), isKanbanShow]);
 
   return (
     <ProjectLayout>
@@ -59,7 +121,8 @@ export default function Project() {
       {/* 칸반 */}
       <KanbanModal
         kanbanTabColor={kanbanTabColor}
-        isKanbanShow={iskanbanShow}
+        isKanbanShow={isKanbanShow}
+        setSearchParams={setSearchParams}
       />
       {/* 투두 */}
       <TodoModal todoTabColor={todoTabColor} isTodoShow={isTodoShow} />

--- a/src/recoil/atoms/todo/todoState.ts
+++ b/src/recoil/atoms/todo/todoState.ts
@@ -1,16 +1,8 @@
 import { atom } from "recoil";
 
-interface TodoStateDefault {
-  todoData: any;
-}
-
-const defaultValue: TodoStateDefault = {
-  todoData: null,
-};
-
 const todoState = atom({
   key: "todoData",
-  default: defaultValue,
+  default: new Map(),
 });
 
 export default todoState;


### PR DESCRIPTION
### ⛳️ Task

#### 라이브러리 설치 / 삭제
- [x] 사용하지 않는 react-beautiful-dnd 라이브러리를 제거했습니다.
- [x] Stage 생성시 고유한 키를 부여하기 위해 uuid 라이브러리 및 Type을 설치했습니다.

#### createCollection.ts
- [x] Stage 및 Todo의 ERD를 개선했습니다.
- [x] 이제 todo는 Stage 관련 정보를 가지고 있지 않습니다. 또한 정렬 순서도 삭제하였습니다.
- [x] Stage는 todoIds라는 배열을 가집니다. 이 배열 및 배열의 인덱스를 이용해 todo의 위치를 기억합니다.
- [x] createTodo가 이제 todoID를 리턴합니다.

#### Project.tsx
- [x] useEffect 훅을 이용해 칸반 선택시 Todo onSnapshot을 생성합니다.
  - todoState 파일을 Map 객체를 이용해 수정했습니다.
- [x] useEffect 훅을 이용해 URL 변경시 isKanbanShow 및 isTodoShow를 state로 관리합니다.

#### CalendarModal.tsx
- [x] 주석 제거

#### CreateKanbanModal.tsx
- [x] 칸반 생성시 기본 Stage의 정보를 변경했습니다.

#### KanbanModal 폴더 내 변경사항
- [x] 기존 Stage.tsx. 컴포넌트를 세분화 및 쉽게 알아볼 수 있도록 이름을 KanbanStageBox.tsx로 변경했습니다
- [x] 컴포넌트 세분화를 위해 Stage.tsx, Todo.tsx 컴포넌트를 추가했습니다.

#### KanbanModal.tsx
- [x] 기존 스타일 컴포넌트의 네이밍 컨벤션을 대거 변경했습니다.
- [x] 기존 KanbanModal.tsx 의 return 중 불필요한 단계를 삭제했습니다.
- [x] KanbanTabColor를 다시 할당하여 Todo 모달 팝업시 색상을 변경했습니다.
- [x] Stage 내 생성한 Todo 클릭시 TodoModal이 팝업됩니다.
- [x] 칸반모달 탭 클릭시 TodoModal이 팝업된 경우 닫힙니다. 

#### KanbanStageBox.tsx
- [x] TodoState와 StageList를 이용하여 만든 데이터를 dnd 라이브러리를 통해 활용하는 구조입니다.
- [x] 현재 onDragEnd 함수에 DB 업데이트 로직 추가 예정입니다.

#### Stage.tsx, Todo.tsx
- [x] KanbanStageBox 내 dnd 라이브러리를 이용해 만든 드래그 가능한 요소입니다.

#### 화이팅 하기
- [x] 화이팅 하기

### ✍️ Note

현재 KanbanModal 내에서 스테이지 생성 및 스테이지 내 투두 생성은 가능하지만
투두 및 스테이지를 드래그 하는 경우는 저장되지 않습니다. 추후 업데이트 예정입니다. (드래그는 자유로이 가능합니다.)

칸반 삭제시 404 가 화면에 나온 뒤 모달이 내려가는 이슈가 있습니다.
현재 로직으로는 당연한 동작입니다. 이후 setTimeOut 등을 이용해 모달이 내려간 이후 삭제가 되도록 수정하면 될 것 같습니다.

### 📸 Screenshot

### 📎 Reference

close #132 
