### PR TITLE
[#142] refactor: 헤더 모달 바깥 선택시 모달 닫히게 수정

### DIFF
--- a/src/components/layout/ModalCommonLayout.tsx
+++ b/src/components/layout/ModalCommonLayout.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, ReactElement } from "react";
+import React, {
+  useRef,
+  useState,
+  useEffect,
+  ReactElement,
+  BaseSyntheticEvent,
+} from "react";
 import { styled } from "styled-components";
 
 interface Props {
@@ -45,7 +51,11 @@ export default function ModalCommon(name: ModalInfo) {
   const { modalIndex, modalSelected, children } = name;
   const [activeIndex, setActiveIndex] = useState<number>();
 
-  const handleClick = () => {
+  useEffect(() => {
+    setActiveIndex(modalSelected);
+  }, [modalSelected]);
+
+  const handleClickBox = () => {
     if (activeIndex === modalIndex) {
       // 같은 모달 아이콘 클릭시 기본 값 -1 부여를 통한 모달 닫힘 처리
       setActiveIndex(-1);
@@ -54,13 +64,38 @@ export default function ModalCommon(name: ModalInfo) {
     }
   };
 
-  useEffect(() => {
-    setActiveIndex(modalSelected);
-  }, [modalSelected]);
+  const handleOutsideClick = () => {
+    // 현재 활성화된 모달의 바깥 영역을 클릭한 경우, 기본 값 -1 부여를 통한 모달 닫힘 처리
+    setActiveIndex(-1);
+  };
+
+  const useOutsideClick = (callback: () => void) => {
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+      const handleClick = (event: BaseSyntheticEvent | MouseEvent) => {
+        // ref가 존재하고, ref 안에 클릭한 부분이 없을 때에만(ref의 바깥쪽을 눌렀을 때) 동작
+        if (ref.current && !ref.current.contains(event.target)) {
+          callback();
+        }
+      };
+
+      document.addEventListener("click", handleClick);
+
+      return () => {
+        document.removeEventListener("click", handleClick);
+      };
+    }, [callback, ref]);
+    return ref;
+  };
+
+  //
+  const ref = useOutsideClick(handleOutsideClick);
 
   return (
-    <ModalLayout>
-      <ModalBox onClick={() => handleClick()}>
+    <ModalLayout className="modallayout">
+      {/* ref 속성에는 커스텀 훅 useOutsideClick으로부터 반환받은 ref가 들어감 */}
+      <ModalBox onClick={handleClickBox} className="modalbox" ref={ref}>
         {children.props.children[0]}
         {activeIndex === modalIndex ? children.props.children[1] : null}
       </ModalBox>

--- a/src/components/layout/ModalCommonLayout.tsx
+++ b/src/components/layout/ModalCommonLayout.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useRef,
-  useState,
-  useEffect,
-  ReactElement,
-  BaseSyntheticEvent,
-} from "react";
+import React, { useRef, useState, useEffect, ReactElement } from "react";
 import { styled } from "styled-components";
 
 interface Props {
@@ -55,6 +49,22 @@ export default function ModalCommon(name: ModalInfo) {
     setActiveIndex(modalSelected);
   }, [modalSelected]);
 
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent): void {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target as Node)
+      ) {
+        setActiveIndex(-1);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [wrapperRef]);
+
   const handleClickBox = () => {
     if (activeIndex === modalIndex) {
       // 같은 모달 아이콘 클릭시 기본 값 -1 부여를 통한 모달 닫힘 처리
@@ -64,38 +74,9 @@ export default function ModalCommon(name: ModalInfo) {
     }
   };
 
-  const handleOutsideClick = () => {
-    // 현재 활성화된 모달의 바깥 영역을 클릭한 경우, 기본 값 -1 부여를 통한 모달 닫힘 처리
-    setActiveIndex(-1);
-  };
-
-  const useOutsideClick = (callback: () => void) => {
-    const ref = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-      const handleClick = (event: BaseSyntheticEvent | MouseEvent) => {
-        // ref가 존재하고, ref 안에 클릭한 부분이 없을 때에만(ref의 바깥쪽을 눌렀을 때) 동작
-        if (ref.current && !ref.current.contains(event.target)) {
-          callback();
-        }
-      };
-
-      document.addEventListener("click", handleClick);
-
-      return () => {
-        document.removeEventListener("click", handleClick);
-      };
-    }, [callback, ref]);
-    return ref;
-  };
-
-  //
-  const ref = useOutsideClick(handleOutsideClick);
-
   return (
-    <ModalLayout className="modallayout">
-      {/* ref 속성에는 커스텀 훅 useOutsideClick으로부터 반환받은 ref가 들어감 */}
-      <ModalBox onClick={handleClickBox} className="modalbox" ref={ref}>
+    <ModalLayout>
+      <ModalBox onClick={handleClickBox} ref={wrapperRef} className="modalBox">
         {children.props.children[0]}
         {activeIndex === modalIndex ? children.props.children[1] : null}
       </ModalBox>


### PR DESCRIPTION
### ⛳️ Task
- [x]  모달 바깥 영역 클릭시 모달 창 닫히게 수정하기
- [x] 화이팅하기

### ✍️ Note

- 이제 활성화된 모달의 바깥 바깥 영역을 선택하면, 모달창이 닫힙니다.
  - 기존 화면 내 요소(캘린더, 칸반 등)의 동작에 영향을 미치지 않습니다. 
### 📸 Screenshot

### 📎 Reference

close #142 