### PR TITLE
[#161] fix: 화면 이동시 activeIndex 기본값으로 초기화

### DIFF
--- a/src/components/layout/ModalCommonLayout.tsx
+++ b/src/components/layout/ModalCommonLayout.tsx
@@ -50,6 +50,7 @@ export default function ModalCommon(name: ModalInfo) {
     setActiveIndex(modalSelected);
   }, [modalSelected]);
 
+  // URL 변경 시(프로젝트 페이지 진입, 칸반 및 투두 선택.. ) 모달 activeIndex 값 초기화해 화면 바뀌었을때 모달 뜨지 않게 수정
   useEffect(() => {
     setActiveIndex(-1);
   }, [path]);

--- a/src/components/layout/ModalCommonLayout.tsx
+++ b/src/components/layout/ModalCommonLayout.tsx
@@ -44,10 +44,15 @@ export const ModalTitle = styled.div`
 export default function ModalCommon(name: ModalInfo) {
   const { modalIndex, modalSelected, children } = name;
   const [activeIndex, setActiveIndex] = useState<number>();
+  const path = window.location.href;
 
   useEffect(() => {
     setActiveIndex(modalSelected);
   }, [modalSelected]);
+
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [path]);
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   useEffect(() => {


### PR DESCRIPTION
### ⛳️ Task

- [x] 화면 이동시 헤더 모달의 activeIndex를 기본 값으로 초기화하기
- [x] 화이팅하기 

### ✍️ Note

### 📸 Screenshot

### 📎 Reference

close #161 