### PR TITLE
[#172] Refactor: 헤더 모달 개선

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { styled } from "styled-components";
 import { useRecoilValue } from "recoil";
+import { useNavigate } from "react-router-dom";
 import userData from "../recoil/atoms/login/userDataState";
 
 import { ReactComponent as headerLogo } from "../assets/logo/headerLogo.svg";
@@ -55,6 +56,7 @@ const HeaderModalBox = styled.div`
 
 const HeaderLogo = styled(headerLogo)`
   height: 1.8rem;
+  cursor: pointer;
 `;
 
 const modals = [
@@ -100,6 +102,7 @@ export default function Header() {
   const userDataState = useRecoilValue(userData);
   const { profile_img_URL: profileImgUrl }: any = userDataState.userData;
   const [selectedModal, setSelectedModal] = useState(-1);
+  const navigate = useNavigate();
 
   const listPageModals = modals.filter(
     (modal) => modal.type === currentHeaderState,
@@ -111,7 +114,7 @@ export default function Header() {
 
   return (
     <HeaderLayout $whichPage={currentHeaderState}>
-      <HeaderLogo />
+      <HeaderLogo onClick={() => navigate("/")} />
       <HeaderIconBox>
         {(currentHeaderState === "list" ? listPageModals : modals).map(
           (modal, index) => (

--- a/src/components/layout/ModalCommonLayout.tsx
+++ b/src/components/layout/ModalCommonLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect, ReactElement } from "react";
+import { useLocation } from "react-router-dom";
 import { styled } from "styled-components";
 
 interface Props {
@@ -44,14 +45,26 @@ export const ModalTitle = styled.div`
 export default function ModalCommon(name: ModalInfo) {
   const { modalIndex, modalSelected, children } = name;
   const [activeIndex, setActiveIndex] = useState<number>();
-  const { pathname } = window.location;
+  const [historyIdx, setHistoryIdx] = useState<number>(
+    window.history.state.idx,
+  );
+  const location = useLocation();
+
   useEffect(() => {
     setActiveIndex(modalSelected);
   }, [modalSelected]);
 
   useEffect(() => {
     setActiveIndex(-1);
-  }, [pathname]);
+  }, [location.pathname]);
+
+  // 페이지 뒤로가기 동작시 변경된 화면에서도 선택된 헤더 모달의 Index가 전달되어 모달이 잠시 켜졌다 사라지는 오류 발생함
+  // window 객체의 history 프로퍼티를 통해 브라우저 히스토리에 접근
+  // state의 idx가 변경된 경우(화면 이동) 렌더링 과정에서 activeindex 기본값으로 변경
+  if (historyIdx !== window.history.state.idx) {
+    setHistoryIdx(window.history.state.idx);
+    setActiveIndex(-1);
+  }
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   useEffect(() => {

--- a/src/components/modal/TutorialModal.tsx
+++ b/src/components/modal/TutorialModal.tsx
@@ -84,9 +84,9 @@ export default function Tutorial() {
   return (
     <ModalArea $dynamicWidth="" $dynamicHeight="auto" onClick={handleClick}>
       <ModalTitle>{`${tutorialTitle} Tutorial`}</ModalTitle>
-      <TutorialTextLayout className="layout">
+      <TutorialTextLayout>
         {posts.slice(offset, page).map((singleElement: any) => (
-          <TutorialTextContent key={singleElement.key} className="content">
+          <TutorialTextContent key={singleElement.key}>
             <TutorialTextParagraph>{singleElement.key}</TutorialTextParagraph>
             {singleElement.content}
           </TutorialTextContent>

--- a/src/components/modal/TutorialModal.tsx
+++ b/src/components/modal/TutorialModal.tsx
@@ -11,6 +11,8 @@ const TutorialTextLayout = styled.div`
 `;
 const TutorialTextContent = styled.div`
   white-space: pre-line;
+  max-height: 15rem;
+  overflow: scroll;
 `;
 const TutorialTextParagraph = styled.p`
   font-size: 1.5rem;

--- a/src/components/modal/TutorialModal.tsx
+++ b/src/components/modal/TutorialModal.tsx
@@ -3,7 +3,12 @@ import { styled } from "styled-components";
 import { ModalArea, ModalTitle } from "../layout/ModalCommonLayout";
 import TutorialPagination from "./TutorialPagination";
 
-const TutorialTextLayout = styled.div``;
+const TutorialTextLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 20rem;
+`;
 const TutorialTextContent = styled.div`
   white-space: pre-line;
 `;
@@ -77,9 +82,9 @@ export default function Tutorial() {
   return (
     <ModalArea $dynamicWidth="" $dynamicHeight="auto" onClick={handleClick}>
       <ModalTitle>{`${tutorialTitle} Tutorial`}</ModalTitle>
-      <TutorialTextLayout>
+      <TutorialTextLayout className="layout">
         {posts.slice(offset, page).map((singleElement: any) => (
-          <TutorialTextContent key={singleElement.key}>
+          <TutorialTextContent key={singleElement.key} className="content">
             <TutorialTextParagraph>{singleElement.key}</TutorialTextParagraph>
             {singleElement.content}
           </TutorialTextContent>


### PR DESCRIPTION
### ⛳️ Task

- [x] 화이팅하기
- [x] 모달 수정하기
### ✍️ Note
- 뒤로 가기 동작시 페이지 이동하는 사이에(프로젝트 페이지 -> 프로젝트 리스트 페이지) 다른 모달이 보여졌다 사라지는 현상을 개선했습니다.
  - window 객체의 history 프로퍼티 안에 있는 state의 idx가 변경될 때(화면 이동이 이루어질 때), ModalCommonLayout.tsx의 렌더링 과정에서 activeIndex를 기본값인 -1로 변경합니다.

- 프로젝트 팀 멤버 모달 선택한 이후 뒤로가기 버튼 선택시 발생하는 오류를 수정했습니다.

- 튜토리얼 모달 컴포넌트의 크기를 설정하였습니다.
  - 튜토리얼 모달 컴포넌트에 min-height 속성을 설정해 크기가 고정될 수 있게끔 수정하였습니다.
  - 내부 컨텐츠에는 max-height 속성과 overflow: scroll 속성을 부여해, 내용이 길어지더라도 컴포넌트 크기에는 변경이 없게 하였습니다.

- 사소하지만 헤더 로고 클릭하면 프로젝트 리스트 페이지로 이동하게 수정해보았습니다.

### 📸 Screenshot

### 📎 Reference

close #172 