### PR TITLE
[#170] feat & design : 칸반 복구 기능 추가

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import styled from "styled-components";
 import { useRecoilValue } from "recoil";
-import trashIcon from "../assets/icons/trashIcon.svg";
 import defaultProjectImg from "../assets/images/deafultProjectImg.jpg";
 import projectState from "../recoil/atoms/project/projectState";
+import TrashBox from "./TrashBox";
 
 const SidebarLayout = styled.div`
   display: flex;
@@ -20,6 +20,8 @@ const ProjectInfoBox = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
+
+  width: 100%;
 `;
 
 const ProjectTitleParagraph = styled.p`
@@ -35,22 +37,6 @@ const ProjectProfileImg = styled.img`
   object-fit: cover;
 
   border-radius: 0.5rem;
-`;
-
-const TrashBox = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  width: auto;
-  height: 2.5rem;
-  background-color: #ffd43b;
-
-  border-radius: 0.3rem;
-`;
-
-const TrashBoxImg = styled.img`
-  width: 1.5rem;
 `;
 
 export default function Sidebar() {
@@ -69,9 +55,7 @@ export default function Sidebar() {
         />
       </ProjectInfoBox>
 
-      <TrashBox>
-        <TrashBoxImg src={trashIcon} alt="TrashIcon" />
-      </TrashBox>
+      <TrashBox />
     </SidebarLayout>
   );
 }

--- a/src/components/TrashBox.tsx
+++ b/src/components/TrashBox.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from "react";
+import styled, { css } from "styled-components";
+import { useRecoilValue } from "recoil";
+import { doc, updateDoc } from "firebase/firestore";
+import { useLocation } from "react-router-dom";
+
+import trashIcon from "../assets/icons/trashIcon.svg";
+import projectState from "../recoil/atoms/project/projectState";
+import { db } from "../firebaseSDK";
+
+const TrashBoxLayout = styled.div`
+  width: 100%;
+`;
+
+const TrashBoxBtn = styled.div`
+  transition: all 0.2s;
+
+  position: relative;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 2.3rem;
+  background-color: ${(props) => props.theme.Color.yellow2};
+  &:hover {
+    background-color: ${(props) => props.theme.Color.yellow1};
+    cursor: pointer;
+  }
+
+  border-radius: 0.3rem;
+
+  z-index: 3;
+`;
+
+const TrashBoxImg = styled.img`
+  width: 1.5rem;
+`;
+
+const DeletedListLayout = styled.div<{ $isShow: boolean }>`
+  position: fixed;
+
+  transition: all 1s ease;
+
+  width: 11.5rem;
+  height: 100%;
+  padding: 1rem 1rem 0 1rem;
+
+  background-color: #f5f5f5;
+  border-radius: 0.3rem;
+
+  top: 14rem;
+  ${(props) =>
+    !props.$isShow &&
+    css`
+      top: 100%;
+    `};
+`;
+
+const DeletedKanbanBox = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
+
+const DeletedKanbanName = styled.p`
+  width: 7rem;
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const WhiteArea = styled.div`
+  position: fixed;
+
+  width: inherit;
+  height: 100%;
+
+  background-color: white;
+  top: calc(100% - 3rem);
+`;
+
+export default function TrashBox() {
+  const { pathname } = useLocation();
+
+  const { deleted_kanban_info_list: deletedKanbanInfoList } =
+    useRecoilValue(projectState).projectData;
+
+  const [isListShow, setIsListShow] = useState(false);
+
+  const handleTrashBoxBtnClick = () => {
+    setIsListShow((prev) => !prev);
+  };
+
+  const handleRestoreCLick = async (id: string) => {
+    const updatedDeletedKanbanIdList = deletedKanbanInfoList.filter(
+      (kanbanInfo: { id: string; name: string }) => kanbanInfo.id !== id,
+    );
+    const projectRef = doc(db, "project", pathname);
+    await updateDoc(projectRef, {
+      deleted_kanban_info_list: updatedDeletedKanbanIdList,
+    });
+    const kanbanRef = doc(db, "project", pathname, "kanban", id);
+    await updateDoc(kanbanRef, {
+      is_deleted: false,
+    });
+  };
+
+  return (
+    <>
+      <TrashBoxLayout>
+        <TrashBoxBtn onClick={handleTrashBoxBtnClick}>
+          <TrashBoxImg src={trashIcon} alt="TrashIcon" />
+        </TrashBoxBtn>
+      </TrashBoxLayout>
+      <DeletedListLayout $isShow={isListShow}>
+        {deletedKanbanInfoList.length === 0 ? "삭제된 칸반이 없습니다." : ""}
+        {deletedKanbanInfoList.map(
+          (kanbanInfo: { id: string; name: string }) => (
+            <DeletedKanbanBox key={kanbanInfo.id}>
+              <DeletedKanbanName>{kanbanInfo.name}</DeletedKanbanName>
+              <button
+                type="button"
+                onClick={() => handleRestoreCLick(kanbanInfo.id)}
+              >
+                복구
+              </button>
+            </DeletedKanbanBox>
+          ),
+        )}
+      </DeletedListLayout>
+      <WhiteArea />
+    </>
+  );
+}

--- a/src/components/layout/ProjectModalLayout.tsx
+++ b/src/components/layout/ProjectModalLayout.tsx
@@ -7,7 +7,7 @@ const ProjectModalLayout = styled.div<{ $isShow: boolean }>`
   position: fixed;
 
   // 헤더 및 사이드바 CSS 변경시 width, height 수정 요망
-  width: calc(100% - 14rem);
+  width: calc(100% - 15.5rem);
   height: calc(100% - 5.5rem);
 
   top: calc(5.75rem);

--- a/src/pages/ProjectListPage/CreateProjectBtn.tsx
+++ b/src/pages/ProjectListPage/CreateProjectBtn.tsx
@@ -50,6 +50,7 @@ interface ProjectData {
   modified_date: FieldValue;
   creater: string;
   is_deleted: boolean;
+  deleted_kanban_info_list: { id: string; name: string }[];
 }
 
 export default function CreateProjectBtn() {
@@ -68,6 +69,7 @@ export default function CreateProjectBtn() {
       modified_date: serverTimestamp(),
       creater: email,
       is_deleted: false,
+      deleted_kanban_info_list: [],
     };
 
     const docRef = await addDoc(collection(db, "project"), projectData);

--- a/src/pages/ProjectPage/CalendarModal/CreateKanbanModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CreateKanbanModal.tsx
@@ -83,13 +83,20 @@ export default function CreateKanbanModal(props: Props) {
 
   const wrapperRef = useRef<HTMLDivElement>(null);
 
+  const resetCreateKanbanModalState = () => {
+    setUserList([]);
+    setKanbanName("");
+    setColor("#3888d8");
+    setIsShow(false);
+  };
+
   useEffect(() => {
     function handleClickOutside(e: MouseEvent): void {
       if (
         wrapperRef.current &&
         !wrapperRef.current.contains(e.target as Node)
       ) {
-        setIsShow(false);
+        resetCreateKanbanModalState();
       }
     }
     document.addEventListener("mousedown", handleClickOutside);
@@ -97,13 +104,6 @@ export default function CreateKanbanModal(props: Props) {
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, [wrapperRef]);
-
-  const resetCreateKanbanModalState = () => {
-    setUserList([]);
-    setKanbanName("");
-    setColor("#3888d8");
-    setIsShow(false);
-  };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setKanbanName(e.target.value);

--- a/src/pages/ProjectPage/KanbanModal/KanbanModal.tsx
+++ b/src/pages/ProjectPage/KanbanModal/KanbanModal.tsx
@@ -16,9 +16,10 @@ import {
 import ErrorPage from "../../../components/ErrorPage";
 import KanbanStageBox from "./KanbanStageBox";
 import CommonInputLayout from "../../../components/layout/CommonInputLayout";
+import projectState from "../../../recoil/atoms/project/projectState";
 
 const KanbanContainer = styled(ProjectModalContentBox)`
-  padding: 2rem;
+  padding: 2rem 2rem 0.5rem 2rem;
 `;
 
 const KanbanInfoLayout = styled.div`
@@ -78,6 +79,9 @@ export default function KanbanModal({ isKanbanShow }: Props) {
   const currentKanban =
     kanbanDataState.get(kanbanId) || kanbanDataState.get(lastKanbanId);
 
+  const { deleted_kanban_info_list: deletedKanbanIdList } =
+    useRecoilValue(projectState).projectData;
+
   useEffect(() => {
     if (!isKanbanShow || kanbanId === "null" || !currentKanban) {
       return;
@@ -87,9 +91,18 @@ export default function KanbanModal({ isKanbanShow }: Props) {
   }, [kanbanId, isKanbanShow, currentKanban]);
 
   const handleDelete = async () => {
+    const projectRef = doc(db, "project", projectId);
+    const deletedKanbanInfo = {
+      id: kanbanId,
+      name: currentKanban.name,
+    };
+    await updateDoc(projectRef, {
+      deleted_kanban_info_list: [deletedKanbanInfo, ...deletedKanbanIdList],
+    });
     await updateDoc(kanbanRef, {
       is_deleted: true,
     });
+
     navigate(`/${projectId}`);
   };
 

--- a/src/pages/ProjectPage/KanbanModal/Stage.tsx
+++ b/src/pages/ProjectPage/KanbanModal/Stage.tsx
@@ -61,6 +61,8 @@ const StageTrashIcon = styled.img`
 `;
 
 const TodoList = styled.div<TodoListProps>`
+  overflow-y: scroll;
+
   flex-grow: 1;
 
   background-color: ${(props) =>

--- a/src/pages/ProjectPage/Project.tsx
+++ b/src/pages/ProjectPage/Project.tsx
@@ -19,9 +19,9 @@ import {
 const ProjectLayout = styled.div`
   position: relative;
 
-  width: 100%;
+  width: calc(100% - 14rem);
   height: 100%;
-  padding: 0.75rem 1.75rem 0 0.5rem;
+  padding: 0.75rem 1rem 0 0.5rem;
 `;
 
 const ProjectLayoutFooter = styled.div`
@@ -30,7 +30,7 @@ const ProjectLayoutFooter = styled.div`
   top: calc(100% - 0.6rem);
 
   /* 사이드바 width 변경시 수정 필요. */
-  width: calc(100% - 14rem);
+  width: calc(100% - 15.5rem);
   height: 0.6rem;
 
   border-radius: 0 0.6rem 0 0;


### PR DESCRIPTION
### ⛳️ Task

- [x] 칸반을 삭제할 경우 project 컬렉션 내 deleted_kanban_info_list배열 내 객체로 삭제한 칸반의 { id, name }이 추가됩니다.
- [x] 복구할 경우 칸반의 is_deleted를 false로 업데이트 하며 deleted_kanban_info_list 내 filter 메서드를 이용해 업데이트 후 DB에 저장합니다.
- [x] Sidebar, Project, ProjectModalLayout 컴포넌트 내 Width 값을 정리했습니다.
  - 기존의 경우 ProjectLayout (위치 : ProjectCheckRoute.tsx) 컴포넌트의 CSS가 display: flex 였지만 화면 내 요소 width의 총합이 100%를 초과해 CSS 가 깨지는 현상 발생, 이를 전체적으로 수정.

### ✍️ Note

### 📸 Screenshot

### 📎 Reference

close #170 