### PR TITLE
[#175] feat : user 하위컬렉션 onSnapshot 생성 및 userProfileModal 적용

### DIFF
--- a/src/api/CreateCollection.tsx
+++ b/src/api/CreateCollection.tsx
@@ -1,6 +1,19 @@
-import { FieldValue, addDoc, collection } from "firebase/firestore";
+import {
+  FieldValue,
+  addDoc,
+  collection,
+  doc,
+  setDoc,
+} from "firebase/firestore";
 import { db } from "../firebaseSDK";
 
+interface UserData {
+  email: string;
+  name: string;
+  intro: string;
+  is_kicked: boolean;
+  profile_img_URL: string;
+}
 interface KanbanData {
   user_list: Array<string>;
   stage_list: Array<Object>;
@@ -31,6 +44,15 @@ interface TodoUpdateData {
   detail: string;
   created_date: FieldValue;
 }
+
+export const createUser = async (
+  documentId: string,
+  userId: string,
+  data: UserData,
+): Promise<void> => {
+  const userRef = doc(db, "project", documentId, "user", userId);
+  await setDoc(userRef, data);
+};
 
 export const createKanban = async (
   documentId: string,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -132,10 +132,7 @@ export default function Header() {
                         objectFit: "cover",
                         borderRadius: "50%",
                       }}
-                      src={
-                        userListData.get(loginEmail) &&
-                        userListData.get(loginEmail).profile_img_URL
-                      }
+                      src={userListData.get(loginEmail).profile_img_URL}
                       alt="modalIcon"
                     />
                   ) : (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,6 +22,7 @@ import UserProfile from "./modal/UserProfileModal";
 // 모달 공통 컴포넌트
 import ModalCommon from "./layout/ModalCommonLayout";
 import headerState from "../recoil/atoms/header/headerState";
+import userListState from "../recoil/atoms/userList/userListState";
 
 interface Props {
   $whichPage?: string;
@@ -91,7 +92,7 @@ const modals = [
   {
     key: "profile",
     icon: "userProfile",
-    type: "list",
+    type: "project",
     content: <UserProfile />,
   },
 ];
@@ -100,7 +101,9 @@ export default function Header() {
   const currentHeaderState = useRecoilValue(headerState);
 
   const userDataState = useRecoilValue(userData);
-  const { profile_img_URL: profileImgUrl }: any = userDataState.userData;
+  const { email: loginEmail }: any = userDataState.userData;
+  const userListData = useRecoilValue(userListState);
+
   const [selectedModal, setSelectedModal] = useState(-1);
   const navigate = useNavigate();
 
@@ -129,7 +132,10 @@ export default function Header() {
                         objectFit: "cover",
                         borderRadius: "50%",
                       }}
-                      src={profileImgUrl}
+                      src={
+                        userListData.get(loginEmail) &&
+                        userListData.get(loginEmail).profile_img_URL
+                      }
                       alt="modalIcon"
                     />
                   ) : (

--- a/src/components/routes/ProjectCheckRoute.tsx
+++ b/src/components/routes/ProjectCheckRoute.tsx
@@ -89,7 +89,6 @@ export default function ProjectCheckRoute() {
         setProjectDataState({
           projectData: projectDoc.data(),
         });
-        setHeaderState("project");
       } else if (!projectDoc.exists()) {
         unsubProject();
         setIs404(true);
@@ -151,6 +150,7 @@ export default function ProjectCheckRoute() {
         setUserDataState((prev) => new Map([...prev, ...addedMap]));
       }
       setIsUserListLoaded(true);
+      setHeaderState("project");
     });
 
     // 클린업 함수. 칸반 데이터 초기화 및 실시간 연결 해제

--- a/src/pages/ProjectListPage/CreateProjectBtn.tsx
+++ b/src/pages/ProjectListPage/CreateProjectBtn.tsx
@@ -14,7 +14,7 @@ import { db } from "../../firebaseSDK";
 import userState from "../../recoil/atoms/login/userDataState";
 import icon_plus_circle from "../../assets/icons/icon_plus_circle.svg";
 import loginState from "../../recoil/atoms/login/loginState";
-import { createKanban } from "../../api/CreateCollection";
+import { createKanban, createUser } from "../../api/CreateCollection";
 
 const CreateBtn = styled.button`
   display: inline;
@@ -93,7 +93,13 @@ export default function CreateProjectBtn() {
       });
     }
 
-    // alert("프로젝트가 생성되었습니다!");
+    await createUser(docRef.id, userCredential.email, {
+      email: userCredential.email,
+      name: userCredential.displayName,
+      intro: "",
+      profile_img_URL: userCredential.photoURL,
+      is_kicked: false,
+    });
   };
 
   return (

--- a/src/recoil/atoms/userList/userListState.ts
+++ b/src/recoil/atoms/userList/userListState.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const userListState = atom({
+  key: "userListData",
+  default: new Map(),
+});
+
+export default userListState;


### PR DESCRIPTION
### ⛳️ Task

- [x] 화이팅하기
- [x]  프로젝트 생성시 생성한 유저를 user 하위컬렉션 내 문서로 생성 (CreateCollection createUser 추가)
- [x] 프로젝트 접근시 projectCheckRoute에서 하위컬렉션 user onSnapshot 동작
- [x] 로그인 정보를 이용하여 userProfileModal 정보 할당 및 업데이트
  - 이제 프로젝트 리스트 페이지에서 유저 모달이 나타나지 않습니다.

### ✍️ Note

### 📸 Screenshot

### 📎 Reference
