### PR TITLE
[#164] 사이드바 최근 칸반 바로가기 기능

### DIFF
--- a/src/components/routes/ProjectCheckRoute.tsx
+++ b/src/components/routes/ProjectCheckRoute.tsx
@@ -13,7 +13,7 @@ import {
 import styled from "styled-components";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 
-import Sidebar from "../Sidebar";
+import Sidebar from "../sidebar/Sidebar";
 import { db } from "../../firebaseSDK";
 import projectState from "../../recoil/atoms/project/projectState";
 import userState from "../../recoil/atoms/login/userDataState";

--- a/src/components/sidebar/RecentKanban.tsx
+++ b/src/components/sidebar/RecentKanban.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from "react";
 import { useSearchParams } from "react-router-dom";
 import { useRecoilValue, useSetRecoilState } from "recoil";
@@ -6,11 +5,6 @@ import styled from "styled-components";
 import recentKanbanState from "../../recoil/atoms/sidebar/recentKanbanState";
 import kanbanState from "../../recoil/atoms/kanban/kanbanState";
 import todoLoaded from "../../recoil/atoms/sidebar/todoLoaded";
-import {
-  ProjectModalContentBox,
-  ProjectModalLayout,
-} from "../layout/ProjectModalLayout";
-import LoadingPage from "../LoadingPage";
 
 const KanbanUrlBox = styled.div`
   background-color: green;
@@ -21,17 +15,14 @@ export default function RecentKanban() {
   const projectId = window.location.pathname.substring(1);
 
   const recentKanbanUrl = useRecoilValue(recentKanbanState);
-  console.log("recentKanbanUrl", recentKanbanUrl);
-  const reversedUrls = recentKanbanUrl
-    ? [...recentKanbanUrl[projectId]].reverse()
-    : null;
+  const reversedUrls =
+    projectId in recentKanbanUrl
+      ? [...recentKanbanUrl[projectId]].reverse()
+      : null;
   const kanbanData = useRecoilValue(kanbanState);
   const urlQueryString = new URLSearchParams(window.location.search);
   const curKanbanId = String(urlQueryString.get("kanbanID"));
-  console.log("reversedUrls", reversedUrls);
-  // console.log("reversedUrls", reversedUrls);
-  console.log("kanbanData", kanbanData);
-  console.log("curKanbanId", curKanbanId);
+
   // 최근 칸반 바로가기 기능
   const handleClick = (kanbanID: string) => {
     // 현재 위치한 페이지가 바로가기 목적지이면 동작 X
@@ -41,26 +32,17 @@ export default function RecentKanban() {
     setIsLoaded(false);
     setSearchParams({ kanbanID });
   };
-  // if (reversedUrls.length === 0 ||) {
-  //   console.log("여기");
-  //   return <span>Recent Kanban</span>;
-  // }
 
   return (
     <>
       <span>Recent Kanban</span>
-      {/* {reversedUrls.length !== 0 
+      {reversedUrls
         ? reversedUrls.map((kanbanID: string) => (
             <KanbanUrlBox key={kanbanID} onClick={() => handleClick(kanbanID)}>
-              (<span>{kanbanData.get(kanbanID).name}</span>)
+              <span>{kanbanData.get(kanbanID).name}</span>
             </KanbanUrlBox>
           ))
-        : null} */}
-      {/* {reversedUrls.map((kanbanID: string) => (
-        <KanbanUrlBox key={kanbanID} onClick={() => handleClick(kanbanID)}>
-          (<span>{kanbanData.get(kanbanID).name}</span>)
-        </KanbanUrlBox>
-      ))} */}
+        : null}
     </>
   );
 }

--- a/src/components/sidebar/RecentKanban.tsx
+++ b/src/components/sidebar/RecentKanban.tsx
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import styled from "styled-components";
+import recentKanbanState from "../../recoil/atoms/sidebar/recentKanbanState";
+import kanbanState from "../../recoil/atoms/kanban/kanbanState";
+import todoLoaded from "../../recoil/atoms/sidebar/todoLoaded";
+import {
+  ProjectModalContentBox,
+  ProjectModalLayout,
+} from "../layout/ProjectModalLayout";
+import LoadingPage from "../LoadingPage";
+
+const KanbanUrlBox = styled.div`
+  background-color: green;
+`;
+export default function RecentKanban() {
+  const [, setSearchParams] = useSearchParams();
+  const setIsLoaded = useSetRecoilState(todoLoaded);
+  const projectId = window.location.pathname.substring(1);
+
+  const recentKanbanUrl = useRecoilValue(recentKanbanState);
+  console.log("recentKanbanUrl", recentKanbanUrl);
+  const reversedUrls = recentKanbanUrl
+    ? [...recentKanbanUrl[projectId]].reverse()
+    : null;
+  const kanbanData = useRecoilValue(kanbanState);
+  const urlQueryString = new URLSearchParams(window.location.search);
+  const curKanbanId = String(urlQueryString.get("kanbanID"));
+  console.log("reversedUrls", reversedUrls);
+  // console.log("reversedUrls", reversedUrls);
+  console.log("kanbanData", kanbanData);
+  console.log("curKanbanId", curKanbanId);
+  // 최근 칸반 바로가기 기능
+  const handleClick = (kanbanID: string) => {
+    // 현재 위치한 페이지가 바로가기 목적지이면 동작 X
+    if (curKanbanId === kanbanID) {
+      return;
+    }
+    setIsLoaded(false);
+    setSearchParams({ kanbanID });
+  };
+  // if (reversedUrls.length === 0 ||) {
+  //   console.log("여기");
+  //   return <span>Recent Kanban</span>;
+  // }
+
+  return (
+    <>
+      <span>Recent Kanban</span>
+      {/* {reversedUrls.length !== 0 
+        ? reversedUrls.map((kanbanID: string) => (
+            <KanbanUrlBox key={kanbanID} onClick={() => handleClick(kanbanID)}>
+              (<span>{kanbanData.get(kanbanID).name}</span>)
+            </KanbanUrlBox>
+          ))
+        : null} */}
+      {/* {reversedUrls.map((kanbanID: string) => (
+        <KanbanUrlBox key={kanbanID} onClick={() => handleClick(kanbanID)}>
+          (<span>{kanbanData.get(kanbanID).name}</span>)
+        </KanbanUrlBox>
+      ))} */}
+    </>
+  );
+}

--- a/src/components/sidebar/RecentKanban.tsx
+++ b/src/components/sidebar/RecentKanban.tsx
@@ -7,7 +7,13 @@ import kanbanState from "../../recoil/atoms/kanban/kanbanState";
 import todoLoaded from "../../recoil/atoms/sidebar/todoLoaded";
 
 const KanbanUrlBox = styled.div`
-  background-color: green;
+  border-radius: 5px;
+  background-color: #eaeaea;
+  margin: 3px 0px;
+  transition: background-color 0.5s ease-in-out;
+  &:hover {
+    background-color: #cacaca;
+  }
 `;
 export default function RecentKanban() {
   const [, setSearchParams] = useSearchParams();

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import styled from "styled-components";
 import { useRecoilValue } from "recoil";
-import trashIcon from "../assets/icons/trashIcon.svg";
-import defaultProjectImg from "../assets/images/deafultProjectImg.jpg";
-import projectState from "../recoil/atoms/project/projectState";
+import trashIcon from "../../assets/icons/trashIcon.svg";
+import defaultProjectImg from "../../assets/images/deafultProjectImg.jpg";
+import projectState from "../../recoil/atoms/project/projectState";
+import RecentKanban from "./RecentKanban";
 
 const SidebarLayout = styled.div`
   display: flex;
@@ -55,20 +56,23 @@ const TrashBoxImg = styled.img`
 
 export default function Sidebar() {
   const { projectData } = useRecoilValue(projectState);
+
   return (
     <SidebarLayout>
-      <ProjectInfoBox>
-        <ProjectTitleParagraph>{projectData.name}</ProjectTitleParagraph>
-        <ProjectProfileImg
-          src={
-            projectData.project_img_URL
-              ? projectData.project_img_URL
-              : defaultProjectImg
-          }
-          alt="Project Profile Img"
-        />
-      </ProjectInfoBox>
-
+      <div>
+        <ProjectInfoBox>
+          <ProjectTitleParagraph>{projectData.name}</ProjectTitleParagraph>
+          <ProjectProfileImg
+            src={
+              projectData.project_img_URL
+                ? projectData.project_img_URL
+                : defaultProjectImg
+            }
+            alt="Project Profile Img"
+          />
+        </ProjectInfoBox>
+        <RecentKanban />
+      </div>
       <TrashBox>
         <TrashBoxImg src={trashIcon} alt="TrashIcon" />
       </TrashBox>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import styled from "styled-components";
 import { useRecoilValue } from "recoil";
-import trashIcon from "../../assets/icons/trashIcon.svg";
 import defaultProjectImg from "../../assets/images/deafultProjectImg.jpg";
 import projectState from "../../recoil/atoms/project/projectState";
 import RecentKanban from "./RecentKanban";
+import TrashBox from "../TrashBox";
 
 const SidebarLayout = styled.div`
   display: flex;
@@ -38,22 +38,6 @@ const ProjectProfileImg = styled.img`
   border-radius: 0.5rem;
 `;
 
-const TrashBox = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  width: auto;
-  height: 2.5rem;
-  background-color: #ffd43b;
-
-  border-radius: 0.3rem;
-`;
-
-const TrashBoxImg = styled.img`
-  width: 1.5rem;
-`;
-
 export default function Sidebar() {
   const { projectData } = useRecoilValue(projectState);
 
@@ -73,9 +57,7 @@ export default function Sidebar() {
         </ProjectInfoBox>
         <RecentKanban />
       </div>
-      <TrashBox>
-        <TrashBoxImg src={trashIcon} alt="TrashIcon" />
-      </TrashBox>
+      <TrashBox />
     </SidebarLayout>
   );
 }

--- a/src/pages/ProjectListPage/DeleteModal.tsx
+++ b/src/pages/ProjectListPage/DeleteModal.tsx
@@ -1,12 +1,14 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from "react";
 import { doc, updateDoc } from "firebase/firestore";
 import styled from "styled-components";
-// import { useRecoilValue } from "recoil";
+import { useRecoilState } from "recoil";
 import { db } from "../../firebaseSDK";
 // import userState from "../../recoil/atoms/login/userDataState";
 // import loginState from "../../recoil/atoms/login/loginState";
 // import deleteStorageImg from "../../utils/deleteStorageImg";
 import ConfirmBtn from "../../components/layout/ConfirmBtnLayout";
+import recentKanbanState from "../../recoil/atoms/sidebar/recentKanbanState";
 
 // 모달
 const ModalContainer = styled.div`
@@ -50,13 +52,16 @@ export default function DeleteModal({
   setOpenModal,
   fetchProjectData,
 }: any) {
-  //   const { userCredential } = useRecoilValue(loginState);
-  //   const { project_list: projectList } = useRecoilValue(userState).userData;
   const docRef = doc(db, "project", projectId);
+  const [recentKanbanId, setRecentKanbanId] = useRecoilState(recentKanbanState);
 
   // 삭제 버튼 클릭 시 동작
   const handleDelete = async () => {
     setOpenModal(false);
+    // 최근 칸반 목록 초기화
+    const newRecentList = { ...recentKanbanId };
+    delete newRecentList[projectId];
+    setRecentKanbanId(newRecentList);
     //   논리적 삭제
     await updateDoc(docRef, {
       is_deleted: true,

--- a/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
+++ b/src/pages/ProjectPage/CalendarModal/CalendarModal.tsx
@@ -335,29 +335,29 @@ export default function CalendarModal({ setSearchParams }: Props) {
     setSearchParams({ kanbanID: eventInfo.publicId });
 
     // local storage에 최근 칸반 주소 저장
-    const output = localStorage.getItem("recentKanban");
-    if (output) {
-      if (projectId in recentKanbanId) {
-        if (recentKanbanId[projectId].includes(eventInfo.publicId)) {
-          const newIds = recentKanbanId[projectId].filter(
-            (id: string) => id !== eventInfo.publicId,
-          );
-          setRecentKanbanId((prev: any) => ({
-            ...prev,
-            [projectId]: [...newIds, eventInfo.publicId],
-          }));
-          return;
-        }
-        if (recentKanbanId[projectId].length >= 3) {
-          const newIds = recentKanbanId[projectId].slice(1);
-          setRecentKanbanId((prev: any) => ({
-            ...prev,
-            [projectId]: [...newIds, eventInfo.publicId],
-          }));
-          return;
-        }
+    if (projectId in recentKanbanId) {
+      // 이미 최근목록에 존재하는 칸반 접속 시 순서 최신화
+      if (recentKanbanId[projectId].includes(eventInfo.publicId)) {
+        const newIds = recentKanbanId[projectId].filter(
+          (id: string) => id !== eventInfo.publicId,
+        );
+        setRecentKanbanId((prev: any) => ({
+          ...prev,
+          [projectId]: [...newIds, eventInfo.publicId],
+        }));
+        return;
+      }
+      // 최근목록 길이 제한
+      if (recentKanbanId[projectId].length >= 3) {
+        const newIds = recentKanbanId[projectId].slice(1);
+        setRecentKanbanId((prev: any) => ({
+          ...prev,
+          [projectId]: [...newIds, eventInfo.publicId],
+        }));
+        return;
       }
     }
+
     setRecentKanbanId((prev: any) => ({
       ...prev,
       [projectId]: Array.isArray(prev[projectId])

--- a/src/pages/ProjectPage/KanbanModal/KanbanModal.tsx
+++ b/src/pages/ProjectPage/KanbanModal/KanbanModal.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { doc, updateDoc } from "firebase/firestore";
 
 import { db } from "../../../firebaseSDK";
@@ -18,6 +18,7 @@ import KanbanStageBox from "./KanbanStageBox";
 import CommonInputLayout from "../../../components/layout/CommonInputLayout";
 import todoLoaded from "../../../recoil/atoms/sidebar/todoLoaded";
 import LoadingPage from "../../../components/LoadingPage";
+import recentKanbanState from "../../../recoil/atoms/sidebar/recentKanbanState";
 
 const KanbanContainer = styled(ProjectModalContentBox)`
   padding: 2rem;
@@ -82,6 +83,8 @@ export default function KanbanModal({ isKanbanShow }: Props) {
 
   const isLoaded = useRecoilValue(todoLoaded);
 
+  const [recentKanbanId, setRecentKanbanId] = useRecoilState(recentKanbanState);
+
   useEffect(() => {
     if (!isKanbanShow || kanbanId === "null" || !currentKanban) {
       return;
@@ -91,6 +94,15 @@ export default function KanbanModal({ isKanbanShow }: Props) {
   }, [kanbanId, isKanbanShow, currentKanban]);
 
   const handleDelete = async () => {
+    // 사이드바 최근 칸반 목록에서 삭제
+    const newIds = recentKanbanId[projectId].filter(
+      (id: string) => id !== kanbanId,
+    );
+    setRecentKanbanId((prev: any) => ({
+      ...prev,
+      [projectId]: [...newIds],
+    }));
+
     await updateDoc(kanbanRef, {
       is_deleted: true,
     });

--- a/src/pages/ProjectPage/KanbanModal/KanbanModal.tsx
+++ b/src/pages/ProjectPage/KanbanModal/KanbanModal.tsx
@@ -16,6 +16,8 @@ import {
 import ErrorPage from "../../../components/ErrorPage";
 import KanbanStageBox from "./KanbanStageBox";
 import CommonInputLayout from "../../../components/layout/CommonInputLayout";
+import todoLoaded from "../../../recoil/atoms/sidebar/todoLoaded";
+import LoadingPage from "../../../components/LoadingPage";
 
 const KanbanContainer = styled(ProjectModalContentBox)`
   padding: 2rem;
@@ -78,6 +80,8 @@ export default function KanbanModal({ isKanbanShow }: Props) {
   const currentKanban =
     kanbanDataState.get(kanbanId) || kanbanDataState.get(lastKanbanId);
 
+  const isLoaded = useRecoilValue(todoLoaded);
+
   useEffect(() => {
     if (!isKanbanShow || kanbanId === "null" || !currentKanban) {
       return;
@@ -108,6 +112,15 @@ export default function KanbanModal({ isKanbanShow }: Props) {
       <ProjectModalLayout $isShow={isKanbanShow}>
         <ProjectModalContentBox>
           <ErrorPage isKanban404 />
+        </ProjectModalContentBox>
+      </ProjectModalLayout>
+    );
+  }
+  if (!isLoaded) {
+    return (
+      <ProjectModalLayout $isShow>
+        <ProjectModalContentBox>
+          <LoadingPage />
         </ProjectModalContentBox>
       </ProjectModalLayout>
     );

--- a/src/pages/ProjectPage/Project.tsx
+++ b/src/pages/ProjectPage/Project.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { useSearchParams } from "react-router-dom";
 
 import { collection, onSnapshot, query, where } from "firebase/firestore";
-import { useSetRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import CalendarModal from "./CalendarModal/CalendarModal";
 import KanbanModal from "./KanbanModal/KanbanModal";
 import TodoModal from "./TodoModal/TodoModal";
@@ -15,6 +15,7 @@ import {
   ProjectModalTabContainer,
   ProjectModalTabText,
 } from "../../components/layout/ProjectModalLayout";
+import todoLoaded from "../../recoil/atoms/sidebar/todoLoaded";
 
 const ProjectLayout = styled.div`
   position: relative;
@@ -44,6 +45,8 @@ export default function Project() {
 
   const [isKanbanShow, setIsKanbanShow] = useState(false);
   const [isTodoShow, setIsTodoShow] = useState(false);
+
+  const [isLoaded, setIsLoaded] = useRecoilState(todoLoaded);
 
   let calendarTabColor = "#FFD43B";
   let kanbanTabColor = "#ffea7a";
@@ -110,6 +113,7 @@ export default function Project() {
       if (searchParams.has("todoID")) {
         setIsTodoShow(true);
       }
+      setIsLoaded(true);
     });
 
     // eslint-disable-next-line consistent-return
@@ -144,7 +148,7 @@ export default function Project() {
         </ProjectModalTabBox>
         <ProjectModalTabBox
           $left={10.25}
-          $isShow={isKanbanShow}
+          $isShow={isLoaded ? isKanbanShow : true}
           onClick={handleKanbanTabClick}
         >
           <ProjectModalTabBackground $color={kanbanTabColor} />

--- a/src/recoil/atoms/sidebar/recentKanbanState.ts
+++ b/src/recoil/atoms/sidebar/recentKanbanState.ts
@@ -1,0 +1,19 @@
+import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
+
+const { persistAtom } = recoilPersist({
+  key: "recentKanban",
+  storage: localStorage,
+});
+
+type RecentKanbanState = {
+  [key: string]: Array<string>;
+};
+
+const recentKanbanState = atom<RecentKanbanState>({
+  key: "recentKanbanId",
+  default: {},
+  effects_UNSTABLE: [persistAtom],
+});
+
+export default recentKanbanState;

--- a/src/recoil/atoms/sidebar/todoLoaded.ts
+++ b/src/recoil/atoms/sidebar/todoLoaded.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const todoLoaded = atom({
+  key: "todoLoaded",
+  default: true,
+});
+
+export default todoLoaded;


### PR DESCRIPTION
### ⛳️ Task

- [x] 화이팅하기

### ✍️ Note
## 최근 칸반 목록 기능
- recentKanbanState를 만들어 전역으로 관리되고, localStorage에 최근 목록이 저장됨
- {[key:string]: Array<string>} 형태로 저장. key는 projectId, Array내 string은 kanbanId
- calendar에서 onClick 이벤트에 기능 추가
- 현재 위치해 있는 칸반에서 해당 칸반 바로가기 클릭 시 동작 X
- 이미 최근 목록에 존재하는 칸반 접속 시 순서 최신화
- 최근 목록 길이 제한
- 프로젝트 삭제 시 최근 칸반 목록 초기화
- 칸반 삭제 시 최근 칸반 목록에서 해당 칸반 삭제
- todoLoaded를 recoil로 관리하고 있고, 이를 통해 isShow를 관리해 칸반에서 칸반으로 바로 이동 시 화면이 내려가다가 바로 올라오는 매끄럽지 않은 현상 보완


### 📸 Screenshot

### 📎 Reference

close #164 