### PR TITLE
refactor : 프로젝트 멤버 모달 recoilState로 변경

### DIFF
--- a/src/components/modal/ProjectMemberModal.tsx
+++ b/src/components/modal/ProjectMemberModal.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-alert */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { useEffect, useState, KeyboardEvent } from "react";
+import React, { useState, KeyboardEvent } from "react";
 import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 import { doc, getDoc, serverTimestamp, updateDoc } from "firebase/firestore";

--- a/src/pages/LoginPage/Login.tsx
+++ b/src/pages/LoginPage/Login.tsx
@@ -85,9 +85,7 @@ export default function Login() {
           await setDoc(doc(db, "user", user.email as string), {
             project_list: [],
             profile_img_URL: user.photoURL,
-            name: user.displayName,
             email: user.email,
-            intro: "",
             is_deleted: false,
           });
         }


### PR DESCRIPTION
### ⛳️ Task

- [x] 화이팅하기
- [x] 유저 초대시 user 하위컬렉션에 추가
- [x]  유저 중복 초대 불가하도록 설정
- [x]  유저 내보낼 시 user 하위컬렉션 내 is_kicked 변경
- [x]  기존 하나의 프로필을 모든 프로젝트에서 사용하는 것에서 각 프로젝트별 프로필을 가지는 것으로 변경
  - 프로필 이미지의 위치 -> {projectId} / user / {userEmail}
- [x] user 컬렉션은 recoil State로 관리하며 자신의 정보는 현재 로그인 한 유저의 email을 key로 이용하여 가져옴
- [x] projectMemberModal 등은 기존에 project 필드 user_list를 사용하던 것들 모두 userState로 변경

close #175 

### ✍️ Note

### 📸 Screenshot

### 📎 Reference
