### PR TITLE
[#185] refactor : ProjectCheckRoute 리팩토링

### DIFF
--- a/src/components/routes/ProjectCheckRoute.tsx
+++ b/src/components/routes/ProjectCheckRoute.tsx
@@ -124,12 +124,29 @@ export default function ProjectCheckRoute() {
     const projectRef = doc(db, "project", pathname);
     const unsubProject = onSnapshot(projectRef, async (projectSnapshot) => {
       // 프로젝트 is_deleted 확인
-      if (projectSnapshot.exists() && !projectSnapshot.data().is_deleted) {
+      if (
+        projectSnapshot.exists() &&
+        !projectSnapshot.data().is_deleted &&
+        projectSnapshot.data().user_list.includes(loginEmail)
+      ) {
         setIsProjectLoaded(true);
         setProjectDataState({
           projectData: projectSnapshot.data(),
         });
-      } else {
+      }
+      if (
+        projectSnapshot.exists() &&
+        !projectSnapshot.data().user_list.includes(loginEmail)
+      ) {
+        unsubProject();
+        setIs403(true);
+      }
+      if (
+        !projectSnapshot.exists() ||
+        (projectSnapshot.exists() &&
+          projectSnapshot.data().user_list.includes(loginEmail) &&
+          projectSnapshot.data().is_deleted)
+      ) {
         unsubProject();
         setIs404(true);
       }
@@ -203,6 +220,7 @@ export default function ProjectCheckRoute() {
         prev.clear();
         return prev;
       });
+      setIs403(false);
       setIs404(false);
       unsubProject();
       unsubKanban();

--- a/src/components/routes/ProjectCheckRoute.tsx
+++ b/src/components/routes/ProjectCheckRoute.tsx
@@ -102,6 +102,8 @@ export default function ProjectCheckRoute() {
         projectDoc.data().user_list.includes(loginEmail)
       ) {
         setIsInviteChecked(true);
+      } else if (!projectDoc.exists()) {
+        setIs404(true);
       } else {
         setIs403(true);
       }
@@ -110,6 +112,7 @@ export default function ProjectCheckRoute() {
 
     return () => {
       setIs403(false);
+      setIs404(false);
       setIsInviteChecked(false);
     };
   }, [pathname]);

--- a/src/components/routes/ProjectCheckRoute.tsx
+++ b/src/components/routes/ProjectCheckRoute.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable consistent-return */
 import React, { useEffect, useState } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import {
@@ -42,22 +43,23 @@ export default function ProjectCheckRoute() {
 
   const { email: loginEmail } = useRecoilValue(userState).userData;
 
+  const [isInviteChecked, setIsInviteChecked] = useState(false);
   const [is403, setIs403] = useState(false);
   const [is404, setIs404] = useState(false);
 
   const setHeaderState = useSetRecoilState(headerState);
 
+  // 초대 리스트 현황 및 프로젝트 유저 리스트 현황 체크
   useEffect(() => {
-    // 프로젝트 문서 onSnapshot
-    let passed = false;
     const projectRef = doc(db, "project", pathname);
-    const unsubProject = onSnapshot(projectRef, async (projectDoc) => {
-      // 초대 리스트에 있을경우 동작하는 로직
+
+    const checkInvite = async () => {
+      const projectDoc = await getDoc(projectRef);
+      // 초대 리스트 검증
       if (
         projectDoc.exists() &&
         projectDoc.data().invited_list.includes(loginEmail)
       ) {
-        passed = true;
         // user의 project_list에 project 추가
         const userRef = doc(db, "user", loginEmail);
         const userSnap: any = await getDoc(userRef);
@@ -92,23 +94,41 @@ export default function ProjectCheckRoute() {
           profile_img_URL: profileImgUrl,
           is_kicked: false,
         });
+        setIsInviteChecked(true);
       }
-      // 프로젝트 존재 및 userList 검증
-      if (
+      // 유저 리스트 검증
+      else if (
         projectDoc.exists() &&
-        !projectDoc.data().is_deleted &&
-        (projectDoc.data().user_list.includes(loginEmail) || passed)
+        projectDoc.data().user_list.includes(loginEmail)
       ) {
+        setIsInviteChecked(true);
+      } else {
+        setIs403(true);
+      }
+    };
+    checkInvite();
+
+    return () => {
+      setIs403(false);
+      setIsInviteChecked(false);
+    };
+  }, [pathname]);
+
+  useEffect(() => {
+    // 프로젝트 초대 현황 로직 우선 확인
+    if (!isInviteChecked) return;
+    // 프로젝트 문서 onSnapshot
+    const projectRef = doc(db, "project", pathname);
+    const unsubProject = onSnapshot(projectRef, async (projectSnapshot) => {
+      // 프로젝트 is_deleted 확인
+      if (projectSnapshot.exists() && !projectSnapshot.data().is_deleted) {
         setIsProjectLoaded(true);
         setProjectDataState({
-          projectData: projectDoc.data(),
+          projectData: projectSnapshot.data(),
         });
-      } else if (!projectDoc.exists()) {
-        unsubProject();
-        setIs404(true);
       } else {
         unsubProject();
-        setIs403(true);
+        setIs404(true);
       }
     });
     // 칸반 컬렉션 onSnapshot
@@ -180,14 +200,13 @@ export default function ProjectCheckRoute() {
         prev.clear();
         return prev;
       });
-      setIs403(false);
       setIs404(false);
       unsubProject();
       unsubKanban();
       unsubUserList();
       setHeaderState("list");
     };
-  }, [pathname]);
+  }, [pathname, isInviteChecked]);
 
   if (is404) {
     return <ErrorPage isProject404 />;

--- a/src/pages/ProjectPage/Project.tsx
+++ b/src/pages/ProjectPage/Project.tsx
@@ -41,7 +41,7 @@ const ProjectLayoutFooter = styled.div`
 
 export default function Project() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const setTestTodoDataState = useSetRecoilState(todoState);
+  const setTodoDataState = useSetRecoilState(todoState);
 
   const [isKanbanShow, setIsKanbanShow] = useState(false);
   const [isTodoShow, setIsTodoShow] = useState(false);
@@ -76,7 +76,7 @@ export default function Project() {
     if (!searchParams.has("kanbanID")) {
       return;
     }
-    setTestTodoDataState(new Map());
+    setTodoDataState(new Map());
     const projectID = window.location.pathname.substring(1);
     const kanbanID = searchParams.get("kanbanID");
     const todoQuery = query(
@@ -93,21 +93,21 @@ export default function Project() {
         }
         // 투두를 수정할 경우
         if (change.type === "modified") {
-          setTestTodoDataState((prev) => {
+          setTodoDataState((prev) => {
             prev.set(change.doc.id, change.doc.data());
             return new Map([...prev]);
           });
         }
         // 투두가 삭제된 경우 (is_deleted 수정 시 쿼리 결과 변경)
         if (change.type === "removed") {
-          setTestTodoDataState((prev) => {
+          setTodoDataState((prev) => {
             prev.delete(change.doc.id);
             return new Map([...prev]);
           });
         }
       });
       if (addedMap.size > 0) {
-        setTestTodoDataState((prev) => new Map([...prev, ...addedMap]));
+        setTodoDataState((prev) => new Map([...prev, ...addedMap]));
       }
       setIsKanbanShow(true);
       if (searchParams.has("todoID")) {


### PR DESCRIPTION
### ⛳️ Task

- [x] 화이팅하기
- [x] ProjectCheckRoute 리팩토링

### ✍️ Note

기존 로직은 project의 onSnapshot을 찍을 때 초대 리스트 및 유저 리스트 검증 로직이 동작했습니다.
이로 인해 다른 onSnapshot 메서드들과 병렬적으로 실행되는 초대유저 추가 로직에 의해 적절하지 않은 타이밍에 계속 userListState를 호출했습니다.
(onSnapshot은 promise를 반환하지 않기 때문에 async / await 등을 이용한 비동기 로직 작성이 불가합니다.)

따라서 초대 현황 및 프로젝트 유저리스트 현황 체크하는 로직을 따로 useEffect 훅 내 비동기 함수로 처리하고,
해당 비동기 함수 호출 결과( isInvitedChecked )에 따라 403 페이지 혹은 프로젝트 / 칸반 / 유저리스트 onSnapshot 을 찍는 useEffect 훅이 동작하도록 작성했습니다.

기존에는 최상위 user 컬렉션에서 데이터를 가져와 이러한 시간차가 없었지만, Project의 하위 컬렉션으로 user를 관리하도록 구조를 변경하면서 이와 같은 문제가 발생한 듯 합니다.

### 📸 Screenshot

### 📎 Reference

close #185 