### PR TITLE
[#189] design: CommonSelectMemberLayout container flex 속성값 추가

### DIFF
--- a/src/components/layout/CommonSelectMemberLayout.tsx
+++ b/src/components/layout/CommonSelectMemberLayout.tsx
@@ -103,6 +103,10 @@ export default function CommonSelectMemberLayout(props: Props) {
           ...baseStyles,
           paddingRight: "0",
         }),
+        container: (baseStyles) => ({
+          ...baseStyles,
+          flex: "1",
+        }),
       }}
     />
   );

--- a/src/components/modal/ProjectMemberModal.tsx
+++ b/src/components/modal/ProjectMemberModal.tsx
@@ -338,7 +338,13 @@ export default function ProjectMemberModal() {
         )}
         {modalIndex === 2 && (
           <GetOutContainer>
-            <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                width: "100%",
+              }}
+            >
               {/* <SelectInput
                 style={{ height: "100%", display: "inline-block" }}
                 onChange={(e) => setSelectedUser(e.target.value)}


### PR DESCRIPTION
### ⛳️ Task

- [x] 칸반 생성 모달, 멤버 내보내기 부분에 적용된 CommonSelectMemberLayout 컴포넌트 수정하기

### ✍️ Note
- react-select 라이브러리의 SELECT 컴포넌트의 container 클래스에 flex-grow 값을 1로 지정해 너비를 확장했습니다.
- ProjectMemberModal의 GetOutContainer 내부의 DIv 요소에 추가로 width 속성에 100% 값을 부여했습니다.
### 📸 Screenshot

### 📎 Reference

close #189 