### PR TITLE
[#221] design: 투두 모달 업데이트 UI 개선

### DIFF
--- a/src/pages/ProjectPage/TodoModal/MarkdownEditor.tsx
+++ b/src/pages/ProjectPage/TodoModal/MarkdownEditor.tsx
@@ -36,7 +36,6 @@ const UpdateList = styled.div`
   max-height: 23rem;
   margin: 0 0 1rem;
 `;
-
 interface UpdateContentInterface {
   writer: string;
   detail: string;
@@ -44,7 +43,19 @@ interface UpdateContentInterface {
   writer_img: string;
 }
 
-export default function MarkdownEditor({ todoRef, todoDataState }: any) {
+interface Props {
+  todoRef: any;
+  todoDataState: any;
+  isUpdateClick: boolean;
+  setIsUpdateClick: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function MarkdownEditor({
+  todoRef,
+  todoDataState,
+  isUpdateClick,
+  setIsUpdateClick,
+}: Props) {
   const [value, setValue] = useState("");
   const { name, profile_img_URL: profileImgUrl } =
     useRecoilValue(userState).userData;
@@ -65,37 +76,49 @@ export default function MarkdownEditor({ todoRef, todoDataState }: any) {
       modified_date: serverTimestamp(),
     });
     setValue("");
+    setIsUpdateClick((prev) => !prev);
   };
 
   return (
     <UpdateContainer>
-      <MDEditor
-        // @ts-ignore
-        onChange={setValue}
-        value={value}
-        preview="edit"
-      />
-      <AddUpdateTitle>
-        <ConfirmBtn
-          type="submit"
-          onClick={handleSubmit}
-          $dynamicWidth="3.5rem"
-          $dynamicHeight="2rem"
-          style={{ fontSize: "0.9rem" }}
-        >
-          등록
-        </ConfirmBtn>
-      </AddUpdateTitle>
-      <UpdateList>
-        {todoDataState.update_list.map((updateContent: any, index: number) => (
-          <UpdateContentBox
-            key={updateContent.created_date.seconds}
-            data={updateContent}
-            todoRef={todoRef}
-            updateIndex={index}
+      {isUpdateClick && (
+        <>
+          <MDEditor
+            // @ts-ignore
+            onChange={setValue}
+            value={value}
+            preview="edit"
           />
-        ))}
-      </UpdateList>
+          <AddUpdateTitle>
+            <ConfirmBtn
+              type="submit"
+              onClick={handleSubmit}
+              $dynamicWidth="3.5rem"
+              $dynamicHeight="2rem"
+              style={{ fontSize: "0.9rem" }}
+            >
+              등록
+            </ConfirmBtn>
+          </AddUpdateTitle>
+        </>
+      )}
+
+      {todoDataState.update_list.length ? (
+        <UpdateList>
+          {todoDataState.update_list.map(
+            (updateContent: any, index: number) => (
+              <UpdateContentBox
+                key={updateContent.created_date.seconds}
+                data={updateContent}
+                todoRef={todoRef}
+                updateIndex={index}
+              />
+            ),
+          )}
+        </UpdateList>
+      ) : (
+        !isUpdateClick && <p>업데이트 내역이 없습니다.</p>
+      )}
     </UpdateContainer>
   );
 }

--- a/src/pages/ProjectPage/TodoModal/TodoModal.tsx
+++ b/src/pages/ProjectPage/TodoModal/TodoModal.tsx
@@ -18,6 +18,7 @@ import CommonSelectMemberLayout from "../../../components/layout/CommonSelectMem
 import TagSelectLayout from "./TagSelectLayout";
 import ErrorPage from "../../../components/ErrorPage";
 import trashIcon from "../../../assets/icons/trashIcon.svg";
+import icon_plus_circle from "../../../assets/icons/icon_plus_circle.svg";
 import kanbanState from "../../../recoil/atoms/kanban/kanbanState";
 
 type Props = {
@@ -129,6 +130,7 @@ export default function TodoModal({ isTodoShow }: Props) {
   const [inputTodoName, setInputTodoName] = useState("");
   const [inputTodoInfo, setInputTodoInfo] = useState("");
   const [userList, setUserList] = useState<any[]>([]);
+  const [isUpdateClick, setIsUpdateClick] = useState(false);
 
   useEffect(() => {
     if (!isTodoShow || todoId === "null" || !currentTodo) {
@@ -306,9 +308,23 @@ export default function TodoModal({ isTodoShow }: Props) {
         <div>
           <TodoTopContainer>
             <TodoTitle>업데이트</TodoTitle>
+            <button
+              type="button"
+              onClick={() => {
+                setIsUpdateClick((prev) => !prev);
+              }}
+              style={{ width: "1rem", height: "1rem", margin: "0 1rem 0 0" }}
+            >
+              <img src={icon_plus_circle} alt="투두 업데이트 추가" />
+            </button>
           </TodoTopContainer>
           <Contour />
-          <MarkdownEditor todoRef={todoRef} todoDataState={currentTodo} />
+          <MarkdownEditor
+            todoRef={todoRef}
+            todoDataState={currentTodo}
+            isUpdateClick={isUpdateClick}
+            setIsUpdateClick={setIsUpdateClick}
+          />
         </div>
       </TodoContainer>
     </ProjectModalLayout>

--- a/src/pages/ProjectPage/TodoModal/UpdateContent.tsx
+++ b/src/pages/ProjectPage/TodoModal/UpdateContent.tsx
@@ -30,7 +30,7 @@ const UpdateContent = styled.div`
   margin: 0.5rem 0;
   border-radius: 10px;
   background-color: white;
-  padding: 1rem;
+  padding: 1rem 0;
 `;
 
 const ChangeUpdateModal = styled(CommonSettingModal)`


### PR DESCRIPTION
### ⛳️ Task

- [x] 화이팅하기
- [x] 투두 업데이트 UI 개선하기

### ✍️ Note
- 해당 투두의 update_list가 비어있는 경우(업데이트 내역이 없는 경우), 업데이트 내역이 없다는 기본 텍스트를 노출합니다.
- plus 아이콘을 추가해 클릭하는 경우 업데이트 등록이 가능한 markdown editor를 보여줍니다.
 
### 📸 Screenshot

### 📎 Reference

close #221 