### PR TITLE
[#247] fix & design : 투두 업데이트 문제 해결 / 투두 업데이트 디자인 수정

### DIFF
--- a/src/api/CreateCollection.tsx
+++ b/src/api/CreateCollection.tsx
@@ -40,7 +40,6 @@ interface TodoData {
 }
 interface TodoUpdateData {
   writer: string;
-  writer_img: string;
   detail: string;
   created_date: FieldValue;
 }

--- a/src/components/layout/ConfirmBtnLayout.tsx
+++ b/src/components/layout/ConfirmBtnLayout.tsx
@@ -21,7 +21,7 @@ const ConfirmBtn = styled.button<Props>`
   border-radius: 7px;
   visibility: ${(props) => (props.$isWritten === "" ? "hidden" : "visible")};
   opacity: ${(props) => (props.$isWritten === "" ? 0 : 1)};
-  transition: all 0.5s;
+  transition: all 0.2s;
   &:hover {
     transition: all 0.5s;
     background-color: ${(props) =>

--- a/src/components/layout/ConfirmBtnLayout.tsx
+++ b/src/components/layout/ConfirmBtnLayout.tsx
@@ -8,6 +8,7 @@ interface Props {
   $fontColor?: string;
   $hoverFontColor?: string;
   $hoverBgColor?: string;
+  $isWritten?: string;
 }
 
 const ConfirmBtn = styled.button<Props>`
@@ -18,6 +19,9 @@ const ConfirmBtn = styled.button<Props>`
     props.$dynamicColor ? props.$dynamicColor : props.theme.Color.mainColor};
   color: ${(props) => (props.$fontColor ? props.$fontColor : "white")};
   border-radius: 7px;
+  visibility: ${(props) => (props.$isWritten === "" ? "hidden" : "visible")};
+  opacity: ${(props) => (props.$isWritten === "" ? 0 : 1)};
+  transition: all 0.5s;
   &:hover {
     transition: all 0.5s;
     background-color: ${(props) =>

--- a/src/pages/ProjectPage/TodoModal/MarkdownEditor.tsx
+++ b/src/pages/ProjectPage/TodoModal/MarkdownEditor.tsx
@@ -10,7 +10,6 @@ import ConfirmBtn from "../../../components/layout/ConfirmBtnLayout";
 const NewMDEditor = styled.div<{ $isUpdateClick: boolean }>`
   transition: all 0.2s ease;
   height: ${(props) => (props.$isUpdateClick ? "auto" : 0)};
-  /* visibility: ${(props) => (props.$isUpdateClick ? "visible" : "hidden")}; */
   opacity: ${(props) => (props.$isUpdateClick ? 1 : 0)};
 `;
 const AddUpdateTitle = styled.div`
@@ -46,7 +45,6 @@ interface UpdateContentInterface {
   writer: string;
   detail: string;
   created_date: Date;
-  writer_img: string;
 }
 
 interface Props {
@@ -63,16 +61,14 @@ export default function MarkdownEditor({
   setIsUpdateClick,
 }: Props) {
   const [value, setValue] = useState("");
-  const { name, profile_img_URL: profileImgUrl } =
-    useRecoilValue(userState).userData;
+  const { email } = useRecoilValue(userState).userData;
 
   // update_list db 업데이트
   const handleSubmit = async () => {
     const newUpdateContent: UpdateContentInterface = {
-      writer: name,
+      writer: email,
       detail: value,
       created_date: new Date(),
-      writer_img: profileImgUrl,
     };
     const todoSnap: any = await getDoc(todoRef);
     const updateContents = todoSnap.data().update_list;

--- a/src/pages/ProjectPage/TodoModal/MarkdownEditor.tsx
+++ b/src/pages/ProjectPage/TodoModal/MarkdownEditor.tsx
@@ -7,6 +7,12 @@ import userState from "../../../recoil/atoms/login/userDataState";
 import UpdateContentBox from "./UpdateContent";
 import ConfirmBtn from "../../../components/layout/ConfirmBtnLayout";
 
+const NewMDEditor = styled.div<{ $isUpdateClick: boolean }>`
+  transition: all 0.2s ease;
+  height: ${(props) => (props.$isUpdateClick ? "auto" : 0)};
+  /* visibility: ${(props) => (props.$isUpdateClick ? "visible" : "hidden")}; */
+  opacity: ${(props) => (props.$isUpdateClick ? 1 : 0)};
+`;
 const AddUpdateTitle = styled.div`
   display: flex;
   justify-content: flex-end;
@@ -81,28 +87,26 @@ export default function MarkdownEditor({
 
   return (
     <UpdateContainer>
-      {isUpdateClick && (
-        <>
-          <MDEditor
-            // @ts-ignore
-            onChange={setValue}
-            value={value}
-            preview="edit"
-          />
-          <AddUpdateTitle>
-            <ConfirmBtn
-              type="submit"
-              onClick={handleSubmit}
-              $dynamicWidth="3.5rem"
-              $dynamicHeight="2rem"
-              $isWritten={value}
-              style={{ fontSize: "0.9rem" }}
-            >
-              등록
-            </ConfirmBtn>
-          </AddUpdateTitle>
-        </>
-      )}
+      <NewMDEditor $isUpdateClick={isUpdateClick}>
+        <MDEditor
+          // @ts-ignore
+          onChange={setValue}
+          value={value}
+          preview="edit"
+        />
+        <AddUpdateTitle>
+          <ConfirmBtn
+            type="submit"
+            onClick={handleSubmit}
+            $dynamicWidth="3.5rem"
+            $dynamicHeight="2rem"
+            $isWritten={value}
+            style={{ fontSize: "0.9rem" }}
+          >
+            등록
+          </ConfirmBtn>
+        </AddUpdateTitle>
+      </NewMDEditor>
 
       {todoDataState.update_list.length ? (
         <UpdateList>

--- a/src/pages/ProjectPage/TodoModal/MarkdownEditor.tsx
+++ b/src/pages/ProjectPage/TodoModal/MarkdownEditor.tsx
@@ -9,9 +9,9 @@ import ConfirmBtn from "../../../components/layout/ConfirmBtnLayout";
 
 const AddUpdateTitle = styled.div`
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
-  margin: 0 0 0.5rem;
+  margin: 0.5rem 0 0;
 `;
 const UpdateContainer = styled.div`
   height: calc(100% - 3.2rem);
@@ -95,6 +95,7 @@ export default function MarkdownEditor({
               onClick={handleSubmit}
               $dynamicWidth="3.5rem"
               $dynamicHeight="2rem"
+              $isWritten={value}
               style={{ fontSize: "0.9rem" }}
             >
               등록

--- a/src/pages/ProjectPage/TodoModal/UpdateContent.tsx
+++ b/src/pages/ProjectPage/TodoModal/UpdateContent.tsx
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from "react";
 import MDEditor from "@uiw/react-md-editor";
 import styled from "styled-components";
 import { getDoc, updateDoc } from "firebase/firestore";
+import { useRecoilValue } from "recoil";
 import settingIcon from "../../../assets/icons/settingIconBlack.svg";
 import yearMonthDayFormat from "../../../utils/yearMonthDayFormat";
 import trashIcon from "../../../assets/icons/trashIcon.svg";
 import pencilIcon from "../../../assets/icons/pencilIcon.svg";
 import reloadIcon from "../../../assets/icons/reloadIcon.svg";
 import CommonSettingModal from "../../../components/layout/CommonSettingModal";
+import userListState from "../../../recoil/atoms/userList/userListState";
 
 const UpdateListHeader = styled.div`
   display: flex;
@@ -43,6 +45,9 @@ export default function UpdateContentBox({ todoRef, data, updateIndex }: any) {
   const [markdownContent, setMarkdownContent] = useState("");
   const [isEditing, setIsEditing] = useState(false);
   const [isSettingOpened, setIsSettingOpened] = useState(false);
+
+  const userListData = useRecoilValue(userListState);
+  const creatorData = userListData.get(data.writer);
 
   const handleMarkdownChange = (edit: any) => {
     setMarkdownContent(edit);
@@ -98,7 +103,7 @@ export default function UpdateContentBox({ todoRef, data, updateIndex }: any) {
       <UpdateListHeader>
         <ManagedUser>
           <img
-            src={data.writer_img}
+            src={creatorData.profile_img_URL}
             alt="프로필사진"
             style={{
               width: "1.5rem",
@@ -108,7 +113,7 @@ export default function UpdateContentBox({ todoRef, data, updateIndex }: any) {
               margin: "0 0.5rem 0 0",
             }}
           />
-          {data.writer}
+          {creatorData.name}
         </ManagedUser>
         <SettingContainer>
           <span style={{ fontSize: "0.8rem", color: "gray" }}>


### PR DESCRIPTION
### ⛳️ Task

- [x] 화이팅하기

### ✍️ Note
####  투두 업데이트 문제 해결 
1. 업데이트 내용 없어도 업데이트 추가 가능했던 문제
- 내용이 존재해야만 '등록' 버튼이 생성되도록 CSS 수정
2. 업데이트에서 작성자 정보가 최신화되지 않던 문제
- db구조 수정 (db에 이름과 이미지 url 저장 -> email 저장하도록 수정)
- email을 이용해 userListState에서 해당 유저 정보를 갖고 옴

#### 투두 업데이트 디자인 수정
- 세부 디자인 수정

### 📸 Screenshot

### 📎 Reference

close #247 