### PR TITLE
[#270] feat: 프로젝트 리스트 페이지 제목 길이 제한 / 초대링크 localhost 제거 

### DIFF
--- a/src/pages/ProjectListPage/InvitationBtn.tsx
+++ b/src/pages/ProjectListPage/InvitationBtn.tsx
@@ -15,11 +15,7 @@ export default function InvitationBtn() {
   const [inputValue, setInputValue] = useState("");
 
   const handleClick = () => {
-    if (
-      isClicked &&
-      (inputValue.includes("calit-2f888.web.app/") ||
-        inputValue.includes("localhost:3000"))
-    ) {
+    if (isClicked && inputValue.includes("calit-2f888.web.app/")) {
       const cutInputValue = inputValue.substring(
         inputValue.lastIndexOf("/") + 1,
       );

--- a/src/pages/ProjectListPage/ProjectCard.tsx
+++ b/src/pages/ProjectListPage/ProjectCard.tsx
@@ -74,10 +74,11 @@ export default function ProjectCard({
         }}
       >
         <CommonInputLayout
-          $dynamicWidth="10rem"
+          $dynamicWidth="calc(100% - 2rem)"
           $dynamicHeight="2rem"
           $dynamicPadding="2px 4px"
           placeholder="제목을 입력해주세요"
+          maxLength={20}
           style={{
             fontWeight: "900",
           }}

--- a/src/utils/handleCopyClipBoard.tsx
+++ b/src/utils/handleCopyClipBoard.tsx
@@ -1,7 +1,7 @@
 // 링크 복사 기능
 const handleCopyClipBoard = async (id: string) => {
-  //   await navigator.clipboard.writeText(`calit-2f888.web.app/${id}`);
-  await navigator.clipboard.writeText(`localhost:3000/${id}`);
+  await navigator.clipboard.writeText(`calit-2f888.web.app/${id}`);
+  // await navigator.clipboard.writeText(`localhost:3000/${id}`);
 };
 
 export default handleCopyClipBoard;


### PR DESCRIPTION
### ⛳️ Task

- [x] 화이팅하기
- [x] 프로젝트 리스트 페이지 내 제목 길이 제한
- [x] 초대링크 localhost 제거
### ✍️ Note
- 프로젝트 리스트에서 프로젝트 제목을 20자까지 작성할 수 있게 공통input layout에 maxlength 속성을 주었습니다.
- 입력한 제목이 잘려보이지 않게, width값을 100% - 2rem으로 수정했습니다.

- src/utils/handleCopyClipBoard.tsx를 통한 링크 복사에서, localhost로 시작하는 주소가 아닌 calit-2f888.web.app/${id} 형태의 주소가 복사되게 주석 위치를 수정했습니다.
- 프로젝트 리스트 페이지 내 초대링크로 입장에서 붙여넣는 inputValue 링크가 localhost를 포함하던 부분을 제거했습니다. 
### 📸 Screenshot

### 📎 Reference

close #270 